### PR TITLE
Réduire le bandeau principal et ajouter un bandeau de statut

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,29 @@
 </head>
 <body class="theme-dark">
   <header class="app-header">
-    <div class="brand">Atom → Univers</div>
-    <nav class="nav-menu" aria-label="Navigation principale">
-      <button class="nav-button active" data-target="game">Jeu</button>
-      <button class="nav-button" data-target="shop">Boutique</button>
-      <button class="nav-button" data-target="info">Infos</button>
-      <button class="nav-button" data-target="options">Options</button>
-    </nav>
+    <div class="header-main">
+      <div class="brand">Atom → Univers</div>
+      <nav class="nav-menu" aria-label="Navigation principale">
+        <button class="nav-button active" data-target="game">Jeu</button>
+        <button class="nav-button" data-target="shop">Boutique</button>
+        <button class="nav-button" data-target="info">Infos</button>
+        <button class="nav-button" data-target="options">Options</button>
+      </nav>
+    </div>
+    <div class="status-bar" aria-live="polite">
+      <div class="status-item status-item--left">
+        <span class="status-label">APC</span>
+        <span class="status-value" id="statusApc">1</span>
+      </div>
+      <div class="status-item status-item--center">
+        <span class="status-label">Atoms</span>
+        <span class="status-value status-value--main" id="statusAtoms">0</span>
+      </div>
+      <div class="status-item status-item--right">
+        <span class="status-label">APS</span>
+        <span class="status-value" id="statusAps">0</span>
+      </div>
+    </div>
   </header>
 
   <main id="pageContainer">

--- a/script.js
+++ b/script.js
@@ -554,6 +554,9 @@ const elements = {
   atomsLifetime: document.getElementById('atomsLifetime'),
   atomsPerClick: document.getElementById('atomsPerClick'),
   atomsPerSecond: document.getElementById('atomsPerSecond'),
+  statusAtoms: document.getElementById('statusAtoms'),
+  statusApc: document.getElementById('statusApc'),
+  statusAps: document.getElementById('statusAps'),
   atomButton: document.getElementById('atomButton'),
   shopList: document.getElementById('shopList'),
   nextMilestone: document.getElementById('nextMilestone'),
@@ -691,6 +694,15 @@ function updateUI() {
   elements.atomsLifetime.textContent = gameState.lifetime.toString();
   elements.atomsPerClick.textContent = `${gameState.perClick.toString()} APC`;
   elements.atomsPerSecond.textContent = `${gameState.perSecond.toString()} APS`;
+  if (elements.statusAtoms) {
+    elements.statusAtoms.textContent = gameState.atoms.toString();
+  }
+  if (elements.statusApc) {
+    elements.statusApc.textContent = gameState.perClick.toString();
+  }
+  if (elements.statusAps) {
+    elements.statusAps.textContent = gameState.perSecond.toString();
+  }
   updateMilestone();
 }
 

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,9 @@
   --card-neon: rgba(90,110,255,0.08);
   --max-width: min(1100px, 92vw);
   --transition: 0.2s ease;
+  --header-padding-y: clamp(0.7rem, 1.12vw, 0.98rem);
+  --header-padding-x: clamp(1.2rem, 2vw, 2.4rem);
+  --status-padding-y: clamp(1.05rem, 1.7vw, 1.5rem);
 }
 
 * {
@@ -47,12 +50,10 @@ body.theme-neon {
   z-index: 20;
   background: rgba(8, 11, 19, 0.72);
   backdrop-filter: blur(12px);
-  padding: clamp(1rem, 1.6vw, 1.4rem) clamp(1.2rem, 2vw, 2.4rem);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.2rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 body.theme-light .app-header {
@@ -65,11 +66,73 @@ body.theme-neon .app-header {
   border-bottom-color: rgba(90, 120, 255, 0.22);
 }
 
+.header-main {
+  padding: var(--header-padding-y) var(--header-padding-x);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
 .brand {
   font-family: 'Orbitron', monospace;
   font-size: clamp(1.1rem, 1.8vw, 1.6rem);
   letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+.status-bar {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  align-items: center;
+  padding: var(--status-padding-y) var(--header-padding-x);
+  gap: clamp(0.6rem, 1vw, 1rem);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.status-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.status-item--left {
+  text-align: left;
+  align-items: flex-start;
+}
+
+.status-item--center {
+  text-align: center;
+  align-items: center;
+}
+
+.status-item--right {
+  text-align: right;
+  align-items: flex-end;
+}
+
+.status-label {
+  font-size: clamp(0.65rem, 1vw, 0.8rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.status-value {
+  font-family: 'Orbitron', monospace;
+  font-size: clamp(1rem, 1.8vw, 1.35rem);
+}
+
+.status-value--main {
+  font-size: clamp(1.4rem, 2.6vw, 1.95rem);
+}
+
+body.theme-light .status-bar {
+  border-top-color: rgba(12, 16, 32, 0.08);
+}
+
+body.theme-neon .status-bar {
+  border-top-color: rgba(90, 120, 255, 0.22);
 }
 
 .nav-menu {


### PR DESCRIPTION
## Summary
- reduce the main header padding and restructure the layout to shrink the primary banner
- add a sticky production status bar that displays APC, total atoms and APS across the top of the app
- update the game UI bindings so the new status bar values stay in sync with the game state

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf37d033c0832e97f961ed3a9ff64e