### PR TITLE
Intensify clicker focus with starfield backdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,36 +37,14 @@
   </header>
 
   <main id="pageContainer">
-    <section id="game" class="page active" aria-labelledby="game-title">
-      <div class="stats-grid">
-        <article class="stat-card">
-          <h2 id="game-title">Atomes</h2>
-          <p class="stat-value" id="atomsTotal">0</p>
-          <p class="stat-sub">Total accumulé : <span id="atomsLifetime">0</span></p>
-        </article>
-        <article class="stat-card">
-          <h3>Production</h3>
-          <div class="stat-row">
-            <span>Atoms par clic</span>
-            <strong id="atomsPerClick">1</strong>
-          </div>
-          <div class="stat-row">
-            <span>Atoms par seconde</span>
-            <strong id="atomsPerSecond">0</strong>
-          </div>
-        </article>
-      </div>
+    <section id="game" class="page active page--void" aria-label="Chambre de création atomique">
+      <div class="starfield" aria-hidden="true"></div>
 
-      <button class="atom-button" id="atomButton" aria-label="Créer des atomes">
-        <span class="atom-core"></span>
-        <span class="atom-ring"></span>
-        <span class="atom-label">Clic !</span>
+      <button class="atom-button" id="atomButton" aria-label="Créer des atomes" type="button">
+        <span class="atom-visual">
+          <img src="Assets/Image/Atom.png" alt="Illustration d'un atome vibrant" class="atom-image" />
+        </span>
       </button>
-
-      <section class="milestones" aria-live="polite">
-        <h3>Prochain objectif</h3>
-        <p id="nextMilestone">Collectez 100 atomes pour débloquer la fusion auto.</p>
-      </section>
     </section>
 
     <section id="shop" class="page" aria-labelledby="shop-title">

--- a/styles.css
+++ b/styles.css
@@ -201,121 +201,166 @@ main {
   display: block;
 }
 
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: clamp(1rem, 2vw, 1.6rem);
-  margin-bottom: clamp(1.2rem, 2vw, 1.8rem);
-}
-
-.stat-card {
-  background: var(--card-dark);
-  border-radius: 18px;
-  padding: clamp(1.2rem, 2vw, 1.6rem);
+.page--void {
+  position: relative;
+  max-width: none;
+  padding: clamp(2.4rem, 7vw, 5rem);
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  box-shadow: 0 20px 40px rgba(0,0,0,0.22);
+  align-items: center;
+  justify-content: center;
+  min-height: clamp(420px, 85vh, 1200px);
+  background: radial-gradient(circle at 50% 20%, rgba(255, 200, 120, 0.08) 0%, rgba(12, 12, 16, 0.92) 45%, #020207 100%);
+  overflow: hidden;
+  isolation: isolate;
 }
 
-body.theme-light .stat-card {
-  background: var(--card-light);
-  box-shadow: 0 18px 36px rgba(12,16,32,0.18);
+body.theme-light .page--void,
+body.theme-neon .page--void {
+  color: var(--fg-dark);
+  background: radial-gradient(circle at 50% 22%, rgba(255, 200, 120, 0.08) 0%, rgba(10, 10, 16, 0.92) 42%, #020207 100%);
 }
 
-body.theme-neon .stat-card {
-  background: var(--card-neon);
-  box-shadow: 0 24px 48px rgba(80, 110, 255, 0.24);
+.page--void::after {
+  content: '';
+  position: absolute;
+  inset: -15%;
+  background: radial-gradient(circle at center, rgba(255, 230, 180, 0.08) 0%, rgba(255, 120, 40, 0.04) 18%, rgba(5, 6, 12, 0.9) 60%, #010103 100%);
+  filter: blur(28px);
+  z-index: 0;
+  pointer-events: none;
 }
 
-.stat-card h2,
-.stat-card h3 {
-  margin: 0;
+.starfield {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.starfield__star {
+  position: absolute;
+  width: 2.5px;
+  height: 2.5px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(var(--star-scale, 1));
+  background: radial-gradient(circle, rgba(255, 235, 190, 0.95) 0%, rgba(255, 210, 150, 0.75) 30%, rgba(255, 210, 150, 0.02) 75%);
+  box-shadow: 0 0 12px rgba(255, 210, 150, 0.35);
+  mix-blend-mode: screen;
+  filter: blur(0.35px);
+  animation: starTwinkle 7.5s ease-in-out infinite;
+}
+
+@keyframes starTwinkle {
+  0%, 100% {
+    opacity: calc(var(--star-opacity, 0.32) * 0.55);
+    transform: translate(-50%, -50%) scale(calc(var(--star-scale, 1) * 0.85));
+  }
+  40% {
+    opacity: calc(var(--star-opacity, 0.32) * 1.65);
+    transform: translate(-50%, -50%) scale(calc(var(--star-scale, 1) * 1.35));
+  }
+  60% {
+    opacity: calc(var(--star-opacity, 0.32) * 1.1);
+    transform: translate(-50%, -50%) scale(calc(var(--star-scale, 1) * 1.1));
+  }
+}
+
+.game-header {
+  text-align: center;
+  margin: 0 auto clamp(1.2rem, 3vw, 2rem);
+}
+
+.game-header h2 {
+  margin: 0 0 0.5rem 0;
   font-family: 'Orbitron', sans-serif;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.stat-value {
-  font-size: clamp(1.8rem, 5vw, 3rem);
-  font-weight: 700;
+.game-sub {
   margin: 0;
-  font-family: 'Orbitron', sans-serif;
-}
-
-.stat-sub {
-  margin: 0;
-  opacity: 0.72;
-  font-size: 0.9rem;
-}
-
-.stat-row {
-  display: flex;
-  justify-content: space-between;
-  font-size: 1rem;
+  opacity: 0.74;
+  font-size: 0.95rem;
 }
 
 .atom-button {
-  width: min(320px, 60vw);
-  height: min(320px, 60vw);
-  border-radius: 50%;
-  border: none;
-  margin: 0 auto;
+  --glow-strength: 0;
+  --glow-color: 255, 236, 170;
+  --shake-distance: 0px;
+  --shake-rotation: 0deg;
   position: relative;
-  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.35), rgba(80,120,255,0.16));
-  box-shadow: 0 24px 60px rgba(40, 80, 255, 0.28);
+  display: block;
+  width: clamp(110px, 24vw, 180px);
+  aspect-ratio: 1 / 1;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
   cursor: pointer;
-  transition: transform 0.12s ease, box-shadow 0.2s ease;
-  overflow: hidden;
+  transition: transform 0.12s ease;
+  z-index: 2;
 }
 
-.atom-button.pulse {
-  transform: scale(0.94);
-  box-shadow: 0 18px 44px rgba(40, 80, 255, 0.36);
-}
-
-.atom-button:active {
-  transform: scale(0.96);
-  box-shadow: 0 16px 40px rgba(40, 80, 255, 0.32);
-}
-
-.atom-core {
+.atom-button::before,
+.atom-button::after {
+  content: '';
   position: absolute;
-  width: 38%;
-  height: 38%;
-  top: 31%;
-  left: 31%;
+  inset: 6%;
   border-radius: 50%;
-  background: radial-gradient(circle, #7fb4ff 0%, #4164ff 55%, #1e2d6a 100%);
-  filter: blur(0.5px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, filter 0.2s ease, transform 0.2s ease;
 }
 
-.atom-ring {
-  position: absolute;
-  width: 74%;
-  height: 74%;
-  top: 13%;
-  left: 13%;
-  border-radius: 50%;
-  border: 2px solid rgba(255,255,255,0.45);
-  animation: spin 6s linear infinite;
+.atom-button::before {
+  background: radial-gradient(circle, rgba(var(--glow-color), calc(0.42 + 0.52 * var(--glow-strength))) 0%, rgba(var(--glow-color), calc(0.22 + 0.45 * var(--glow-strength))) 42%, rgba(var(--glow-color), 0) 72%);
+  filter: blur(calc(22px + 96px * var(--glow-strength)));
+  opacity: calc(0.52 + 0.48 * var(--glow-strength));
+  transform: scale(calc(0.85 + 0.6 * var(--glow-strength)));
+  mix-blend-mode: screen;
+}
+
+.atom-button::after {
+  inset: -8%;
+  box-shadow:
+    0 0 calc(40px + 90px * var(--glow-strength)) rgba(var(--glow-color), calc(0.24 + 0.5 * var(--glow-strength))),
+    0 0 calc(80px + 140px * var(--glow-strength)) rgba(var(--glow-color), calc(0.12 + 0.35 * var(--glow-strength)));
+  opacity: calc(0.45 + 0.45 * var(--glow-strength));
+}
+
+.atom-button.is-pressed {
+  transform: scale(0.97);
+}
+
+.atom-visual {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  animation: rumble 0.18s infinite;
+  animation-play-state: paused;
   transform-origin: center;
 }
 
-.atom-label {
-  position: absolute;
-  bottom: 14%;
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: 'Orbitron', sans-serif;
-  letter-spacing: 0.24em;
-  font-size: 0.8rem;
-  text-transform: uppercase;
+.atom-button.is-active .atom-visual {
+  animation-play-state: running;
 }
 
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+.atom-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter:
+    drop-shadow(0 0 calc(24px + 68px * var(--glow-strength)) rgba(var(--glow-color), calc(0.45 + 0.52 * var(--glow-strength))))
+    drop-shadow(0 0 calc(45px + 120px * var(--glow-strength)) rgba(var(--glow-color), calc(0.18 + 0.35 * var(--glow-strength))));
+  transition: filter 0.14s ease;
+}
+
+@keyframes rumble {
+  0% { transform: translate(0, 0) rotate(0); }
+  25% { transform: translate(calc(var(--shake-distance) * 0.6), calc(var(--shake-distance) * -0.55)) rotate(calc(var(--shake-rotation) * -1)); }
+  50% { transform: translate(calc(var(--shake-distance) * -0.8), calc(var(--shake-distance) * 0.65)) rotate(calc(var(--shake-rotation) * 0.7)); }
+  75% { transform: translate(calc(var(--shake-distance) * 0.5), calc(var(--shake-distance) * 0.45)) rotate(calc(var(--shake-rotation) * -0.5)); }
+  100% { transform: translate(0, 0) rotate(0); }
 }
 
 .milestones {


### PR DESCRIPTION
## Summary
- simplify the active game page to keep only the atom image centered on a dark void backdrop
- amplify the click-driven rumble, glow and color ramp so the atom reacts strongly even at moderate click speeds
- generate an animated starfield behind the atom with randomized twinkling particles to keep the scene lively

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf3e931e0c832eb96e542b554edd2f