### PR TITLE
Limit clicker to main page and center atom

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,10 +98,6 @@
     </section>
   </main>
 
-  <footer class="app-footer">
-    <p>Projet Atom → Univers &mdash; Expérience clicker scientifique</p>
-  </footer>
-
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -571,8 +571,7 @@ let targetClickStrength = 0;
 let displayedClickStrength = 0;
 
 function isGamePageActive() {
-  const active = document.querySelector('.page.active');
-  return active && active.id === 'game';
+  return document.body.dataset.activePage === 'game';
 }
 
 function updateClickHistory(now = performance.now()) {
@@ -684,11 +683,22 @@ function shouldTriggerGlobalClick(event) {
 
 function showPage(pageId) {
   elements.pages.forEach(page => {
-    page.classList.toggle('active', page.id === pageId);
+    const isActive = page.id === pageId;
+    page.classList.toggle('active', isActive);
+    page.toggleAttribute('hidden', !isActive);
   });
   elements.navButtons.forEach(btn => {
     btn.classList.toggle('active', btn.dataset.target === pageId);
   });
+  document.body.dataset.activePage = pageId;
+  document.body.classList.toggle('view-game', pageId === 'game');
+}
+
+const initiallyActivePage = document.querySelector('.page.active') || elements.pages[0];
+if (initiallyActivePage) {
+  showPage(initiallyActivePage.id);
+} else {
+  document.body.classList.remove('view-game');
 }
 
 elements.navButtons.forEach(btn => {

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,7 @@ main {
   flex: 1;
   display: flex;
   justify-content: center;
+  align-items: stretch;
 }
 
 .page {
@@ -205,13 +206,15 @@ main {
   position: relative;
   max-width: none;
   padding: clamp(2.4rem, 7vw, 5rem);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: clamp(420px, 85vh, 1200px);
+  min-height: max(100%, clamp(420px, 85vh, 1200px));
   background: radial-gradient(circle at 50% 20%, rgba(255, 200, 120, 0.08) 0%, rgba(12, 12, 16, 0.92) 45%, #020207 100%);
   overflow: hidden;
   isolation: isolate;
+}
+
+.page--void.active {
+  display: grid;
+  place-items: center;
 }
 
 body.theme-light .page--void,
@@ -511,13 +514,6 @@ body.theme-light select {
   margin: 0;
   opacity: 0.7;
   font-size: 0.9rem;
-}
-
-.app-footer {
-  text-align: center;
-  padding: 1.2rem 1rem 1.6rem;
-  font-size: 0.85rem;
-  opacity: 0.64;
 }
 
 .toast {


### PR DESCRIPTION
## Summary
- ensure navigation updates the active page state so the clicker only appears on the Atomes view
- center the atom illustration within the main view and remove the footer banner from the layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf478407c8832e92e5ac86f6185a39