### PR TITLE
Embed element info panel inside periodic grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,42 @@
     <section id="tableau" class="page page--table" aria-label="Tableau périodique des éléments">
       <div class="periodic-table-wrapper" role="presentation">
         <div class="periodic-table" id="periodicTable" role="grid" aria-label="Tableau périodique des éléments">
+          <aside class="element-info-panel" id="elementInfoPanel" aria-live="polite">
+            <p class="element-info-panel__placeholder" id="elementInfoPlaceholder">
+              Sélectionnez un élément pour afficher ses propriétés.
+            </p>
+            <div class="element-info-panel__content" id="elementInfoContent" hidden>
+              <header class="element-info-panel__header">
+                <span class="element-info-panel__number" id="elementInfoNumber"></span>
+                <div class="element-info-panel__identity">
+                  <span class="element-info-panel__symbol" id="elementInfoSymbol"></span>
+                  <span class="element-info-panel__name" id="elementInfoName"></span>
+                </div>
+              </header>
+              <dl class="element-info-panel__details">
+                <div class="element-info-panel__row">
+                  <dt>Famille</dt>
+                  <dd id="elementInfoCategory"></dd>
+                </div>
+                <div class="element-info-panel__row">
+                  <dt>Masse atomique</dt>
+                  <dd id="elementInfoMass"></dd>
+                </div>
+                <div class="element-info-panel__row">
+                  <dt>Période</dt>
+                  <dd id="elementInfoPeriod"></dd>
+                </div>
+                <div class="element-info-panel__row">
+                  <dt>Groupe</dt>
+                  <dd id="elementInfoGroup"></dd>
+                </div>
+                <div class="element-info-panel__row">
+                  <dt>Collection</dt>
+                  <dd id="elementInfoCollection"></dd>
+                </div>
+              </dl>
+            </div>
+          </aside>
           <!-- Le tableau est généré dynamiquement par script.js -->
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -478,6 +478,10 @@ const periodicElements = Array.isArray(globalThis.PERIODIC_ELEMENTS)
 
 const TOTAL_ELEMENT_COUNT = periodicElements.length;
 
+const periodicElementIndex = new Map(
+  periodicElements.map(def => [def.id, def])
+);
+
 const CATEGORY_LABELS = {
   'alkali-metal': 'métal alcalin',
   'alkaline-earth-metal': 'métal alcalino-terreux',
@@ -643,6 +647,17 @@ const elements = {
   starfield: document.querySelector('.starfield'),
   shopList: document.getElementById('shopList'),
   periodicTable: document.getElementById('periodicTable'),
+  elementInfoPanel: document.getElementById('elementInfoPanel'),
+  elementInfoPlaceholder: document.getElementById('elementInfoPlaceholder'),
+  elementInfoContent: document.getElementById('elementInfoContent'),
+  elementInfoNumber: document.getElementById('elementInfoNumber'),
+  elementInfoSymbol: document.getElementById('elementInfoSymbol'),
+  elementInfoName: document.getElementById('elementInfoName'),
+  elementInfoCategory: document.getElementById('elementInfoCategory'),
+  elementInfoMass: document.getElementById('elementInfoMass'),
+  elementInfoPeriod: document.getElementById('elementInfoPeriod'),
+  elementInfoGroup: document.getElementById('elementInfoGroup'),
+  elementInfoCollection: document.getElementById('elementInfoCollection'),
   collectionProgress: document.getElementById('elementCollectionProgress'),
   nextMilestone: document.getElementById('nextMilestone'),
   themeSelect: document.getElementById('themeSelect'),
@@ -652,6 +667,7 @@ const elements = {
 
 const shopRows = new Map();
 const periodicCells = new Map();
+let selectedElementId = null;
 
 function formatAtomicMass(value) {
   if (value == null) return '';
@@ -667,10 +683,114 @@ function formatAtomicMass(value) {
   return String(value);
 }
 
+function updateElementInfoPanel(definition) {
+  const panel = elements.elementInfoPanel;
+  const placeholder = elements.elementInfoPlaceholder;
+  const content = elements.elementInfoContent;
+  if (!panel) return;
+
+  if (!definition) {
+    if (panel.dataset.category) {
+      delete panel.dataset.category;
+    }
+    if (content) {
+      content.hidden = true;
+    }
+    if (placeholder) {
+      placeholder.hidden = false;
+    }
+    return;
+  }
+
+  if (definition.category) {
+    panel.dataset.category = definition.category;
+  } else if (panel.dataset.category) {
+    delete panel.dataset.category;
+  }
+
+  if (placeholder) {
+    placeholder.hidden = true;
+  }
+  if (content) {
+    content.hidden = false;
+  }
+
+  if (elements.elementInfoNumber) {
+    elements.elementInfoNumber.textContent =
+      definition.atomicNumber != null ? definition.atomicNumber : '—';
+  }
+  if (elements.elementInfoSymbol) {
+    elements.elementInfoSymbol.textContent = definition.symbol ?? '';
+  }
+  if (elements.elementInfoName) {
+    elements.elementInfoName.textContent = definition.name ?? '';
+  }
+  if (elements.elementInfoCategory) {
+    const label = definition.category
+      ? CATEGORY_LABELS[definition.category] || definition.category
+      : '—';
+    elements.elementInfoCategory.textContent = label;
+  }
+  if (elements.elementInfoMass) {
+    const massText = formatAtomicMass(definition.atomicMass);
+    elements.elementInfoMass.textContent = massText || '—';
+  }
+  if (elements.elementInfoPeriod) {
+    elements.elementInfoPeriod.textContent =
+      definition.period != null ? definition.period : '—';
+  }
+  if (elements.elementInfoGroup) {
+    elements.elementInfoGroup.textContent =
+      definition.group != null ? definition.group : '—';
+  }
+  if (elements.elementInfoCollection) {
+    const entry = gameState.elements?.[definition.id];
+    elements.elementInfoCollection.textContent = entry?.owned ? 'Possédé' : 'Non possédé';
+  }
+}
+
+function selectPeriodicElement(id, { focus = false } = {}) {
+  if (!id || !periodicElementIndex.has(id)) {
+    selectedElementId = null;
+    periodicCells.forEach(cell => {
+      cell.classList.remove('is-selected');
+      cell.setAttribute('aria-pressed', 'false');
+    });
+    updateElementInfoPanel(null);
+    return;
+  }
+
+  selectedElementId = id;
+  periodicCells.forEach((cell, elementId) => {
+    const isSelected = elementId === id;
+    cell.classList.toggle('is-selected', isSelected);
+    cell.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+  });
+
+  const definition = periodicElementIndex.get(id);
+  updateElementInfoPanel(definition);
+
+  if (focus) {
+    const target = periodicCells.get(id);
+    if (target) {
+      target.focus();
+    }
+  }
+}
+
 function renderPeriodicTable() {
   if (!elements.periodicTable) return;
+  const infoPanel = elements.elementInfoPanel;
+  if (infoPanel) {
+    infoPanel.remove();
+  }
+
   elements.periodicTable.innerHTML = '';
   periodicCells.clear();
+
+  if (infoPanel) {
+    elements.periodicTable.appendChild(infoPanel);
+  }
 
   if (!periodicElements.length) {
     const placeholder = document.createElement('p');
@@ -680,6 +800,7 @@ function renderPeriodicTable() {
     if (elements.collectionProgress) {
       elements.collectionProgress.textContent = 'Collection en préparation';
     }
+    selectPeriodicElement(null);
     return;
   }
 
@@ -726,9 +847,10 @@ function renderPeriodicTable() {
     cell.innerHTML = `
       <span class="periodic-element__number">${def.atomicNumber}</span>
       <span class="periodic-element__symbol">${def.symbol}</span>
-      <span class="periodic-element__name">${def.name}</span>
-      <span class="periodic-element__mass">${massText}</span>
     `;
+    cell.setAttribute('aria-pressed', 'false');
+    cell.addEventListener('click', () => selectPeriodicElement(def.id));
+    cell.addEventListener('focus', () => selectPeriodicElement(def.id));
 
     const state = gameState.elements[def.id];
     if (state?.owned) {
@@ -740,6 +862,13 @@ function renderPeriodicTable() {
   });
 
   elements.periodicTable.appendChild(fragment);
+  if (selectedElementId && periodicCells.has(selectedElementId)) {
+    selectPeriodicElement(selectedElementId);
+  } else if (periodicElements.length) {
+    selectPeriodicElement(periodicElements[0].id);
+  } else {
+    selectPeriodicElement(null);
+  }
   updateCollectionDisplay();
 }
 
@@ -759,6 +888,10 @@ function updateCollectionDisplay() {
     const entry = gameState.elements?.[id];
     cell.classList.toggle('is-owned', Boolean(entry?.owned));
   });
+
+  if (selectedElementId && periodicElementIndex.has(selectedElementId)) {
+    updateElementInfoPanel(periodicElementIndex.get(selectedElementId));
+  }
 }
 
 let toastElement = null;

--- a/styles.css
+++ b/styles.css
@@ -226,7 +226,7 @@ main {
   margin: 0 auto;
   padding: clamp(0.5rem, 1vw, 1rem);
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
   min-height: 0;
   overflow: auto;
@@ -249,10 +249,11 @@ main {
   --category-border: rgba(255, 255, 255, 0.1);
   position: relative;
   display: grid;
-  grid-template-rows: auto auto auto auto;
+  grid-template-rows: auto 1fr;
   justify-items: center;
-  gap: 0.18rem;
-  padding: clamp(0.35rem, 0.9vw, 0.55rem);
+  align-items: center;
+  gap: clamp(0.1rem, 0.5vw, 0.25rem);
+  padding: clamp(0.45rem, 1vw, 0.65rem);
   border-radius: 12px;
   background: linear-gradient(150deg, var(--category-strong), var(--category-weak));
   border: 1px solid var(--category-border);
@@ -276,6 +277,11 @@ main {
   box-shadow: 0 0 0 2px rgba(76, 141, 255, 0.35);
 }
 
+.periodic-element.is-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(76, 141, 255, 0.55);
+}
+
 .periodic-element__number {
   font-size: clamp(0.6rem, 0.9vw, 0.75rem);
   opacity: 0.7;
@@ -284,7 +290,7 @@ main {
 
 .periodic-element__symbol {
   font-family: 'Orbitron', sans-serif;
-  font-size: clamp(1.1rem, 2.6vw, 1.8rem);
+  font-size: clamp(1.2rem, 3vw, 2rem);
   letter-spacing: 0.08em;
 }
 
@@ -299,6 +305,96 @@ main {
   opacity: 0.72;
 }
 
+.element-info-panel {
+  --category-strong: rgba(255, 255, 255, 0.08);
+  --category-weak: rgba(255, 255, 255, 0.02);
+  --category-border: rgba(255, 255, 255, 0.1);
+  grid-column: 3 / 13;
+  grid-row: 1 / 4;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.8rem, 1.5vw, 1.15rem);
+  padding: clamp(1.1rem, 2.2vw, 1.6rem);
+  border-radius: 16px;
+  background: linear-gradient(150deg, var(--category-strong), var(--category-weak));
+  border: 1px solid var(--category-border);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+  color: inherit;
+  min-width: 0;
+  min-height: 0;
+}
+
+.element-info-panel__placeholder {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.75;
+  line-height: 1.5;
+}
+
+.element-info-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.8rem, 1.6vw, 1.2rem);
+}
+
+.element-info-panel__header {
+  display: flex;
+  align-items: baseline;
+  gap: clamp(0.75rem, 1.5vw, 1rem);
+}
+
+.element-info-panel__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.element-info-panel__number {
+  font-size: clamp(0.75rem, 1vw, 0.9rem);
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.element-info-panel__symbol {
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(2.2rem, 4.5vw, 3.2rem);
+  letter-spacing: 0.1em;
+}
+
+.element-info-panel__name {
+  font-size: clamp(1rem, 2.4vw, 1.4rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.element-info-panel__details {
+  display: grid;
+  gap: clamp(0.45rem, 1vw, 0.7rem);
+  margin: 0;
+}
+
+.element-info-panel__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: clamp(0.85rem, 1.5vw, 1rem);
+}
+
+.element-info-panel__row dt {
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+.element-info-panel__row dd {
+  margin: 0;
+  text-align: right;
+  font-weight: 500;
+}
+
 .periodic-placeholder {
   margin: 0;
   padding: clamp(1rem, 2vw, 1.4rem);
@@ -309,61 +405,71 @@ main {
   opacity: 0.75;
 }
 
-.periodic-element[data-category='alkali-metal'] {
+.periodic-element[data-category='alkali-metal'],
+.element-info-panel[data-category='alkali-metal'] {
   --category-strong: rgba(255, 146, 70, 0.38);
   --category-weak: rgba(255, 146, 70, 0.12);
   --category-border: rgba(255, 146, 70, 0.4);
 }
 
-.periodic-element[data-category='alkaline-earth-metal'] {
+.periodic-element[data-category='alkaline-earth-metal'],
+.element-info-panel[data-category='alkaline-earth-metal'] {
   --category-strong: rgba(255, 211, 95, 0.36);
   --category-weak: rgba(255, 211, 95, 0.12);
   --category-border: rgba(255, 211, 95, 0.36);
 }
 
-.periodic-element[data-category='transition-metal'] {
+.periodic-element[data-category='transition-metal'],
+.element-info-panel[data-category='transition-metal'] {
   --category-strong: rgba(82, 200, 235, 0.36);
   --category-weak: rgba(82, 200, 235, 0.12);
   --category-border: rgba(82, 200, 235, 0.36);
 }
 
-.periodic-element[data-category='post-transition-metal'] {
+.periodic-element[data-category='post-transition-metal'],
+.element-info-panel[data-category='post-transition-metal'] {
   --category-strong: rgba(200, 150, 255, 0.36);
   --category-weak: rgba(200, 150, 255, 0.12);
   --category-border: rgba(200, 150, 255, 0.36);
 }
 
-.periodic-element[data-category='metalloid'] {
+.periodic-element[data-category='metalloid'],
+.element-info-panel[data-category='metalloid'] {
   --category-strong: rgba(130, 220, 160, 0.32);
   --category-weak: rgba(130, 220, 160, 0.12);
   --category-border: rgba(130, 220, 160, 0.32);
 }
 
-.periodic-element[data-category='nonmetal'] {
+.periodic-element[data-category='nonmetal'],
+.element-info-panel[data-category='nonmetal'] {
   --category-strong: rgba(110, 170, 255, 0.36);
   --category-weak: rgba(110, 170, 255, 0.14);
   --category-border: rgba(110, 170, 255, 0.34);
 }
 
-.periodic-element[data-category='halogen'] {
+.periodic-element[data-category='halogen'],
+.element-info-panel[data-category='halogen'] {
   --category-strong: rgba(255, 120, 200, 0.36);
   --category-weak: rgba(255, 120, 200, 0.14);
   --category-border: rgba(255, 120, 200, 0.34);
 }
 
-.periodic-element[data-category='noble-gas'] {
+.periodic-element[data-category='noble-gas'],
+.element-info-panel[data-category='noble-gas'] {
   --category-strong: rgba(180, 140, 255, 0.36);
   --category-weak: rgba(180, 140, 255, 0.14);
   --category-border: rgba(180, 140, 255, 0.34);
 }
 
-.periodic-element[data-category='lanthanide'] {
+.periodic-element[data-category='lanthanide'],
+.element-info-panel[data-category='lanthanide'] {
   --category-strong: rgba(255, 184, 120, 0.34);
   --category-weak: rgba(255, 184, 120, 0.12);
   --category-border: rgba(255, 184, 120, 0.32);
 }
 
-.periodic-element[data-category='actinide'] {
+.periodic-element[data-category='actinide'],
+.element-info-panel[data-category='actinide'] {
   --category-strong: rgba(255, 130, 150, 0.34);
   --category-weak: rgba(255, 130, 150, 0.12);
   --category-border: rgba(255, 130, 150, 0.32);


### PR DESCRIPTION
## Summary
- move the element info panel into the periodic table grid so it occupies rows 1-3 and columns 3-12
- update the periodic table renderer to keep the info panel mounted while regenerating the grid
- adjust the panel styling to span the reserved grid area while preserving the dynamic category theming

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf5efa4738832ebcb1b8e23861c63d