### PR TITLE
Refonte de la page infos et suivi des statistiques

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,22 +99,116 @@
     </section>
 
     <section id="info" class="page" aria-labelledby="info-title">
-      <article class="info-card">
-        <h2 id="info-title">Bienvenue dans Atom → Univers</h2>
-        <p>Ce clicker vous fait gravir les échelles de la matière, d’un simple atome jusqu’aux structures les plus vastes de l’univers. Cliquez pour créer des atomes, automatisez la production et gérez judicieusement vos améliorations pour atteindre des grandeurs inouïes.</p>
-        <h3>Concepts clés</h3>
-        <ul>
-          <li><strong>APC</strong> – Atomes par clic. Chaque pression sur le noyau en produit cette quantité.</li>
-          <li><strong>APS</strong> – Atomes par seconde. Générés automatiquement grâce aux améliorations.</li>
-          <li><strong>Système de nombres à layers</strong> – Les valeurs dépassant l’entendement sont représentées avec des couches exponentielles. Vous verrez des notations comme <code>10^123</code> ou même des tours d’exponentielles.</li>
-        </ul>
-        <h3>Conseils</h3>
-        <ul>
-          <li>Montez vos clics pour amorcer la progression.</li>
-          <li>Investissez tôt dans la production automatique pour profiter du temps réel.</li>
-          <li>Revenez régulièrement : le jeu continue de produire lorsque vous êtes absent (si vous laissez l’onglet ouvert).</li>
-        </ul>
-      </article>
+      <h2 id="info-title" class="visually-hidden">Informations de progression</h2>
+      <div class="info-grid">
+        <article class="info-card info-card--production" aria-labelledby="info-aps-title">
+          <header class="info-card__header">
+            <h3 id="info-aps-title">Production automatique (APS)</h3>
+            <p class="info-card__subtitle">Synthèse par seconde</p>
+          </header>
+          <dl class="info-metrics">
+            <div class="info-metrics__row">
+              <dt>Total</dt>
+              <dd id="infoApsTotal">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Base</dt>
+              <dd id="infoApsBase">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Bonus additifs</dt>
+              <dd id="infoApsAdditionTotal">+0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Multiplicateur global</dt>
+              <dd id="infoApsMultiplierTotal">×1,00</dd>
+            </div>
+          </dl>
+          <div class="info-bonus">
+            <h4>Bonus additifs</h4>
+            <ul id="infoApsAdditions" class="info-bonus__list" aria-label="Bonus additifs APS"></ul>
+          </div>
+          <div class="info-bonus">
+            <h4>Bonus multiplicateurs</h4>
+            <ul id="infoApsMultipliers" class="info-bonus__list" aria-label="Bonus multiplicateurs APS"></ul>
+          </div>
+        </article>
+
+        <article class="info-card info-card--production" aria-labelledby="info-apc-title">
+          <header class="info-card__header">
+            <h3 id="info-apc-title">Production manuelle (APC)</h3>
+            <p class="info-card__subtitle">Atomes par clic</p>
+          </header>
+          <dl class="info-metrics">
+            <div class="info-metrics__row">
+              <dt>Total</dt>
+              <dd id="infoApcTotal">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Base</dt>
+              <dd id="infoApcBase">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Bonus additifs</dt>
+              <dd id="infoApcAdditionTotal">+0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Multiplicateur global</dt>
+              <dd id="infoApcMultiplierTotal">×1,00</dd>
+            </div>
+          </dl>
+          <div class="info-bonus">
+            <h4>Bonus additifs</h4>
+            <ul id="infoApcAdditions" class="info-bonus__list" aria-label="Bonus additifs APC"></ul>
+          </div>
+          <div class="info-bonus">
+            <h4>Bonus multiplicateurs</h4>
+            <ul id="infoApcMultipliers" class="info-bonus__list" aria-label="Bonus multiplicateurs APC"></ul>
+          </div>
+        </article>
+
+        <article class="info-card info-card--stats" aria-labelledby="info-session-title">
+          <header class="info-card__header">
+            <h3 id="info-session-title">Session en cours</h3>
+            <p class="info-card__subtitle">Données depuis le chargement</p>
+          </header>
+          <dl class="info-metrics">
+            <div class="info-metrics__row">
+              <dt>Atomes gagnés</dt>
+              <dd id="infoSessionAtoms">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Clics manuels</dt>
+              <dd id="infoSessionClicks">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Durée en ligne</dt>
+              <dd id="infoSessionDuration">0s</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="info-card info-card--stats" aria-labelledby="info-global-title">
+          <header class="info-card__header">
+            <h3 id="info-global-title">Progression globale</h3>
+            <p class="info-card__subtitle">Statistiques sauvegardées</p>
+          </header>
+          <dl class="info-metrics">
+            <div class="info-metrics__row">
+              <dt>Atomes gagnés</dt>
+              <dd id="infoGlobalAtoms">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Clics manuels</dt>
+              <dd id="infoGlobalClicks">0</dd>
+            </div>
+            <div class="info-metrics__row">
+              <dt>Durée de jeu</dt>
+              <dd id="infoGlobalDuration">0s</dd>
+            </div>
+          </dl>
+        </article>
+      </div>
     </section>
 
     <section id="options" class="page" aria-labelledby="options-title">

--- a/styles.css
+++ b/styles.css
@@ -866,19 +866,147 @@ body.theme-neon .shop-item__action:disabled {
   }
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.info-grid {
+  display: grid;
+  gap: clamp(1.2rem, 2.4vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
 .info-card {
   background: var(--card-dark);
   border-radius: 18px;
   padding: clamp(1.4rem, 2.4vw, 2rem);
   box-shadow: 0 24px 48px rgba(0,0,0,0.22);
   line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body.theme-light .info-card {
+  background: var(--card-light);
+  box-shadow: 0 24px 48px rgba(12, 16, 32, 0.12);
+}
+
+body.theme-neon .info-card {
+  background: var(--card-neon);
+  box-shadow: 0 24px 48px rgba(80, 100, 255, 0.18);
 }
 
 .info-card h2,
-.info-card h3 {
+.info-card h3,
+.info-card h4 {
   font-family: 'Orbitron', sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.12em;
+}
+
+.info-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.info-card__subtitle {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.6;
+  margin: 0;
+}
+
+.info-metrics {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.info-metrics__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1.2rem;
+}
+
+.info-metrics__row dt {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.info-metrics__row dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-align: right;
+}
+
+.info-bonus {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.info-card h4 {
+  font-size: 0.75rem;
+  margin: 0;
+  opacity: 0.68;
+}
+
+.info-bonus__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.info-bonus__entry {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.info-bonus__label {
+  opacity: 0.75;
+}
+
+.info-bonus__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.info-bonus__empty {
+  opacity: 0.5;
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .info-card {
+    padding: clamp(1.2rem, 4vw, 1.6rem);
+  }
 }
 
 .options-grid {


### PR DESCRIPTION
## Résumé
- refonte de la page Infos pour afficher le détail des APS/APC et les statistiques de session et globales
- ajout d'un suivi persistant des bonus, clics manuels et durées de jeu dans la sauvegarde
- stylisation de la nouvelle grille d'informations et des listes de bonus

## Tests
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68cf6ecc86dc832ebeac2bc239321b2f