### PR TITLE
Refine options reset flow and autosave frequency

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,14 +225,9 @@
             </select>
           </div>
         </div>
-        <div class="option-card">
-          <h3>Progression</h3>
-          <div class="option-row">
-            <button id="saveButton" class="primary">Sauvegarder maintenant</button>
-            <button id="resetButton" class="danger">Réinitialiser</button>
-          </div>
-          <p class="option-note">Les sauvegardes sont automatiques toutes les 30 secondes.</p>
-        </div>
+      </div>
+      <div class="options-reset">
+        <button id="resetButton" class="danger">Réinitialiser</button>
       </div>
     </section>
   </main>

--- a/script.js
+++ b/script.js
@@ -718,7 +718,6 @@ const elements = {
   collectionProgress: document.getElementById('elementCollectionProgress'),
   nextMilestone: document.getElementById('nextMilestone'),
   themeSelect: document.getElementById('themeSelect'),
-  saveButton: document.getElementById('saveButton'),
   resetButton: document.getElementById('resetButton'),
   infoApsTotal: document.getElementById('infoApsTotal'),
   infoApsBase: document.getElementById('infoApsBase'),
@@ -1570,16 +1569,20 @@ elements.themeSelect.addEventListener('change', event => {
   showToast('Thème mis à jour');
 });
 
-elements.saveButton.addEventListener('click', () => {
-  saveGame();
-  showToast('Sauvegarde manuelle effectuée');
-});
-
 elements.resetButton.addEventListener('click', () => {
-  if (confirm('Réinitialiser la progression ? Cette action est irréversible.')) {
-    resetGame();
-    showToast('Progression réinitialisée');
+  const confirmationWord = 'RESET';
+  const promptMessage = `Réinitialisation complète du jeu. Tapez "${confirmationWord}" pour confirmer.\nCette action est irréversible.`;
+  const response = prompt(promptMessage);
+  if (response == null) {
+    showToast('Réinitialisation annulée');
+    return;
   }
+  if (response.trim().toUpperCase() !== confirmationWord) {
+    showToast('Mot de confirmation incorrect');
+    return;
+  }
+  resetGame();
+  showToast('Progression réinitialisée');
 });
 
 function serializeState() {
@@ -1720,7 +1723,7 @@ function loop(now) {
     lastUIUpdate = now;
   }
 
-  if (now - lastSaveTime > 30000) {
+  if (now - lastSaveTime > 5000) {
     saveGame();
     lastSaveTime = now;
   }

--- a/styles.css
+++ b/styles.css
@@ -1014,6 +1014,16 @@ body.theme-neon .info-card {
   gap: clamp(1rem, 2vw, 1.6rem);
 }
 
+#options.page.active {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.2rem, 2vw, 1.8rem);
+}
+
+#options.page {
+  position: relative;
+}
+
 .option-card {
   background: var(--card-dark);
   border-radius: 18px;
@@ -1021,6 +1031,16 @@ body.theme-neon .info-card {
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+}
+
+.options-reset {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.options-reset > #resetButton {
+  align-self: flex-end;
 }
 
 .option-row {


### PR DESCRIPTION
## Summary
- remove the manual save controls from the options view and keep only the reset action anchored bottom-right
- add a confirmation prompt requiring the player to type RESET before wiping progress
- increase the autosave cadence to every 5 seconds to keep progress up to date

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf746d21ec832e9338893efad8e2ba