### PR TITLE
Add periodic elements metadata to game config

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -128,5 +128,834 @@ const GAME_CONFIG = {
       amount: { type: 'layer1', value: 8 },
       text: 'Accumulez 10^8 atomes pour préparer la prochaine ère.'
     }
+  ],
+
+  elements: [
+    {
+      numero: 1,
+      name: 'Hydrogène',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 2,
+      name: 'Hélium',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 3,
+      name: 'Lithium',
+      famille: 'alkali-metal',
+      rarete: 'alkali-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 4,
+      name: 'Béryllium',
+      famille: 'alkaline-earth-metal',
+      rarete: 'alkaline-earth-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 5,
+      name: 'Bore',
+      famille: 'metalloid',
+      rarete: 'metalloid',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 6,
+      name: 'Carbone',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 7,
+      name: 'Azote',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 8,
+      name: 'Oxygène',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 9,
+      name: 'Fluor',
+      famille: 'halogen',
+      rarete: 'halogen',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 10,
+      name: 'Néon',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 11,
+      name: 'Sodium',
+      famille: 'alkali-metal',
+      rarete: 'alkali-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 12,
+      name: 'Magnésium',
+      famille: 'alkaline-earth-metal',
+      rarete: 'alkaline-earth-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 13,
+      name: 'Aluminium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 14,
+      name: 'Silicium',
+      famille: 'metalloid',
+      rarete: 'metalloid',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 15,
+      name: 'Phosphore',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 16,
+      name: 'Soufre',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 17,
+      name: 'Chlore',
+      famille: 'halogen',
+      rarete: 'halogen',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 18,
+      name: 'Argon',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 19,
+      name: 'Potassium',
+      famille: 'alkali-metal',
+      rarete: 'alkali-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 20,
+      name: 'Calcium',
+      famille: 'alkaline-earth-metal',
+      rarete: 'alkaline-earth-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 21,
+      name: 'Scandium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 22,
+      name: 'Titane',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 23,
+      name: 'Vanadium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 24,
+      name: 'Chrome',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 25,
+      name: 'Manganèse',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 26,
+      name: 'Fer',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 27,
+      name: 'Cobalt',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 28,
+      name: 'Nickel',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 29,
+      name: 'Cuivre',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 30,
+      name: 'Zinc',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 31,
+      name: 'Gallium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 32,
+      name: 'Germanium',
+      famille: 'metalloid',
+      rarete: 'metalloid',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 33,
+      name: 'Arsenic',
+      famille: 'metalloid',
+      rarete: 'metalloid',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 34,
+      name: 'Sélénium',
+      famille: 'nonmetal',
+      rarete: 'nonmetal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 35,
+      name: 'Brome',
+      famille: 'halogen',
+      rarete: 'halogen',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 36,
+      name: 'Krypton',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 37,
+      name: 'Rubidium',
+      famille: 'alkali-metal',
+      rarete: 'alkali-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 38,
+      name: 'Strontium',
+      famille: 'alkaline-earth-metal',
+      rarete: 'alkaline-earth-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 39,
+      name: 'Yttrium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 40,
+      name: 'Zirconium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 41,
+      name: 'Niobium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 42,
+      name: 'Molybdène',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 43,
+      name: 'Technétium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 44,
+      name: 'Ruthénium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 45,
+      name: 'Rhodium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 46,
+      name: 'Palladium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 47,
+      name: 'Argent',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 48,
+      name: 'Cadmium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 49,
+      name: 'Indium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 50,
+      name: 'Étain',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 51,
+      name: 'Antimoine',
+      famille: 'metalloid',
+      rarete: 'metalloid',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 52,
+      name: 'Tellure',
+      famille: 'metalloid',
+      rarete: 'metalloid',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 53,
+      name: 'Iode',
+      famille: 'halogen',
+      rarete: 'halogen',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 54,
+      name: 'Xénon',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 55,
+      name: 'Césium',
+      famille: 'alkali-metal',
+      rarete: 'alkali-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 56,
+      name: 'Baryum',
+      famille: 'alkaline-earth-metal',
+      rarete: 'alkaline-earth-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 57,
+      name: 'Lanthane',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 58,
+      name: 'Cérium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 59,
+      name: 'Praséodyme',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 60,
+      name: 'Néodyme',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 61,
+      name: 'Prométhium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 62,
+      name: 'Samarium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 63,
+      name: 'Europium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 64,
+      name: 'Gadolinium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 65,
+      name: 'Terbium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 66,
+      name: 'Dysprosium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 67,
+      name: 'Holmium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 68,
+      name: 'Erbium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 69,
+      name: 'Thulium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 70,
+      name: 'Ytterbium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 71,
+      name: 'Lutécium',
+      famille: 'lanthanide',
+      rarete: 'lanthanide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 72,
+      name: 'Hafnium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 73,
+      name: 'Tantale',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 74,
+      name: 'Tungstène',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 75,
+      name: 'Rhénium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 76,
+      name: 'Osmium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 77,
+      name: 'Iridium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 78,
+      name: 'Platine',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 79,
+      name: 'Or',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 80,
+      name: 'Mercure',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 81,
+      name: 'Thallium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 82,
+      name: 'Plomb',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 83,
+      name: 'Bismuth',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 84,
+      name: 'Polonium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 85,
+      name: 'Astate',
+      famille: 'halogen',
+      rarete: 'halogen',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 86,
+      name: 'Radon',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 87,
+      name: 'Francium',
+      famille: 'alkali-metal',
+      rarete: 'alkali-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 88,
+      name: 'Radium',
+      famille: 'alkaline-earth-metal',
+      rarete: 'alkaline-earth-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 89,
+      name: 'Actinium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 90,
+      name: 'Thorium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 91,
+      name: 'Protactinium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 92,
+      name: 'Uranium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 93,
+      name: 'Neptunium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 94,
+      name: 'Plutonium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 95,
+      name: 'Américium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 96,
+      name: 'Curium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 97,
+      name: 'Berkélium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 98,
+      name: 'Californium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 99,
+      name: 'Einsteinium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 100,
+      name: 'Fermium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 101,
+      name: 'Mendélévium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 102,
+      name: 'Nobélium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 103,
+      name: 'Lawrencium',
+      famille: 'actinide',
+      rarete: 'actinide',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 104,
+      name: 'Rutherfordium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 105,
+      name: 'Dubnium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 106,
+      name: 'Seaborgium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 107,
+      name: 'Bohrium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 108,
+      name: 'Hassium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 109,
+      name: 'Meitnérium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 110,
+      name: 'Darmstadtium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 111,
+      name: 'Roentgenium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 112,
+      name: 'Copernicium',
+      famille: 'transition-metal',
+      rarete: 'transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 113,
+      name: 'Nihonium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 114,
+      name: 'Flérovium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 115,
+      name: 'Moscovium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 116,
+      name: 'Livermorium',
+      famille: 'post-transition-metal',
+      rarete: 'post-transition-metal',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 117,
+      name: 'Tennesse',
+      famille: 'halogen',
+      rarete: 'halogen',
+      bonus: 'ajoute +1 au APS flat'
+    },
+    {
+      numero: 118,
+      name: 'Oganesson',
+      famille: 'noble-gas',
+      rarete: 'noble-gas',
+      bonus: 'ajoute +1 au APS flat'
+    }
   ]
 };


### PR DESCRIPTION
## Summary
- add the 118 periodic elements to the game configuration with immutable metadata (number, name, family)
- initialize each element with a placeholder rarity matching its family and a default "ajoute +1 au APS flat" bonus description

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf7b012378832e93c500adf9bb5699