### PR TITLE
Improve info panel production breakdown readability

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -49,6 +49,28 @@ const GAME_CONFIG = {
   },
 
   /**
+   * Ordre d'affichage des étapes de calcul des productions dans l'onglet Infos.
+   * Chaque entrée correspond à un identifiant d'étape connu du jeu. La liste
+   * peut être réorganisée ou complétée pour s'adapter à de futurs bonus.
+   */
+  infoPanels: {
+    productionOrder: [
+      'baseFlat',
+      'shopFlat',
+      'elementFlat',
+      'shopMultiplier',
+      'rarityMultiplier:commun',
+      'rarityMultiplier:essentiel',
+      'rarityMultiplier:stellaire',
+      'rarityMultiplier:singulier',
+      'rarityMultiplier:mythique',
+      'rarityMultiplier:irreel',
+      'trophyMultiplier',
+      'total'
+    ]
+  },
+
+  /**
    * Définitions complètes des améliorations de la boutique.
    * Chaque entrée décrit :
    * - baseCost : coût initial de l'amélioration.

--- a/index.html
+++ b/index.html
@@ -121,32 +121,7 @@
             <h3 id="info-aps-title">Production automatique (APS)</h3>
             <p class="info-card__subtitle">Synthèse par seconde</p>
           </header>
-          <dl class="info-metrics">
-            <div class="info-metrics__row">
-              <dt>Total</dt>
-              <dd id="infoApsTotal">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Base</dt>
-              <dd id="infoApsBase">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Bonus additifs</dt>
-              <dd id="infoApsAdditionTotal">+0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Multiplicateur global</dt>
-              <dd id="infoApsMultiplierTotal">×1,00</dd>
-            </div>
-          </dl>
-          <div class="info-bonus">
-            <h4>Bonus additifs</h4>
-            <ul id="infoApsAdditions" class="info-bonus__list" aria-label="Bonus additifs APS"></ul>
-          </div>
-          <div class="info-bonus">
-            <h4>Bonus multiplicateurs</h4>
-            <ul id="infoApsMultipliers" class="info-bonus__list" aria-label="Bonus multiplicateurs APS"></ul>
-          </div>
+          <ul id="infoApsBreakdown" class="production-breakdown" aria-label="Détail du calcul APS"></ul>
         </article>
 
         <article class="info-card info-card--production" aria-labelledby="info-apc-title">
@@ -154,32 +129,7 @@
             <h3 id="info-apc-title">Production manuelle (APC)</h3>
             <p class="info-card__subtitle">Atomes par clic</p>
           </header>
-          <dl class="info-metrics">
-            <div class="info-metrics__row">
-              <dt>Total</dt>
-              <dd id="infoApcTotal">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Base</dt>
-              <dd id="infoApcBase">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Bonus additifs</dt>
-              <dd id="infoApcAdditionTotal">+0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Multiplicateur global</dt>
-              <dd id="infoApcMultiplierTotal">×1,00</dd>
-            </div>
-          </dl>
-          <div class="info-bonus">
-            <h4>Bonus additifs</h4>
-            <ul id="infoApcAdditions" class="info-bonus__list" aria-label="Bonus additifs APC"></ul>
-          </div>
-          <div class="info-bonus">
-            <h4>Bonus multiplicateurs</h4>
-            <ul id="infoApcMultipliers" class="info-bonus__list" aria-label="Bonus multiplicateurs APC"></ul>
-          </div>
+          <ul id="infoApcBreakdown" class="production-breakdown" aria-label="Détail du calcul APC"></ul>
         </article>
 
         <article class="info-card info-card--stats" aria-labelledby="info-session-title">

--- a/styles.css
+++ b/styles.css
@@ -1189,46 +1189,57 @@ body.theme-neon .info-card {
   text-align: right;
 }
 
-.info-bonus {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.info-card h4 {
-  font-size: 0.75rem;
-  margin: 0;
-  opacity: 0.68;
-}
-
-.info-bonus__list {
+.production-breakdown {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.55rem;
 }
 
-.info-bonus__entry {
+.production-breakdown__row {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
   gap: 1rem;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
 }
 
-.info-bonus__label {
-  opacity: 0.75;
+.production-breakdown__row--total {
+  padding-top: 0.6rem;
+  margin-top: 0.3rem;
+  border-top: 1px solid rgba(255,255,255,0.12);
+  font-size: 1rem;
 }
 
-.info-bonus__value {
-  font-variant-numeric: tabular-nums;
+body.theme-light .production-breakdown__row--total {
+  border-color: rgba(12,16,32,0.12);
+}
+
+body.theme-neon .production-breakdown__row--total {
+  border-color: rgba(80,100,255,0.24);
+}
+
+.production-breakdown__label {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.78rem;
+  opacity: 0.7;
+}
+
+.production-breakdown__row--total .production-breakdown__label {
+  opacity: 0.9;
+}
+
+.production-breakdown__value {
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
 }
 
-.info-bonus__empty {
-  opacity: 0.5;
-  font-style: italic;
+.production-breakdown__row--multiplier .production-breakdown__value {
+  color: var(--accent);
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- replace the APS/APC info sections with a single configurable breakdown list that highlights base, flat bonuses, multipliers and the final total
- add a game configuration entry to control the display order of production steps, including per-rarity multipliers
- refresh styles to match the new layout and update production calculations to feed the enhanced breakdown data

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf8a6971c8832e8cf2fc632354c19c