### PR TITLE
Ajoute des frénésies temporaires pour l’APS et l’APC

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -49,6 +49,23 @@ const GAME_CONFIG = {
   },
 
   /**
+   * Paramètres du système de frénésie.
+   * - displayDurationMs : durée d'affichage des icônes (en millisecondes).
+   * - effectDurationMs : durée du bonus une fois collecté.
+   * - multiplier : multiplicateur appliqué à la production visée.
+   * - spawnChancePerSecond : probabilités d'apparition par seconde (APC / APS).
+   */
+  frenzies: {
+    displayDurationMs: 5000,
+    effectDurationMs: 30000,
+    multiplier: 2,
+    spawnChancePerSecond: {
+      perClick: 0.01,
+      perSecond: 0.01
+    }
+  },
+
+  /**
    * Ordre d'affichage des étapes de calcul des productions dans l'onglet Infos.
    * Chaque entrée correspond à un identifiant d'étape connu du jeu. La liste
    * peut être réorganisée ou complétée pour s'adapter à de futurs bonus.
@@ -60,6 +77,7 @@ const GAME_CONFIG = {
       'elementFlat',
       'shopBonus1',
       'shopBonus2',
+      'frenzy',
       'rarityMultiplier:commun',
       'rarityMultiplier:essentiel',
       'rarityMultiplier:stellaire',

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
           <img src="Assets/Image/Atom.png" alt="Illustration d'un atome vibrant" class="atom-image" draggable="false" />
         </span>
       </button>
+      <div class="frenzy-layer" id="frenzyLayer" aria-hidden="true"></div>
     </section>
 
     <section id="shop" class="page" aria-labelledby="shop-title">

--- a/styles.css
+++ b/styles.css
@@ -792,6 +792,78 @@ body.theme-neon .page--void {
   pointer-events: none;
 }
 
+.frenzy-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.frenzy-token {
+  position: absolute;
+  width: clamp(54px, 9vw, 96px);
+  aspect-ratio: 1 / 1;
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  transform: translate(-50%, -50%) scale(0.85);
+  transition: transform 0.18s ease, opacity 0.18s ease;
+  animation: frenzy-pop 0.3s ease-out forwards;
+  pointer-events: auto;
+}
+
+.frenzy-token:hover {
+  transform: translate(-50%, -50%) scale(0.95);
+}
+
+.frenzy-token:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  transform: translate(-50%, -50%) scale(0.95);
+}
+
+.frenzy-token img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.frenzy-token--perClick {
+  filter:
+    drop-shadow(0 12px 18px rgba(0, 0, 0, 0.38))
+    drop-shadow(0 0 12px rgba(255, 120, 64, 0.6))
+    drop-shadow(0 16px 28px rgba(255, 120, 64, 0.25));
+}
+
+.frenzy-token--perSecond {
+  filter:
+    drop-shadow(0 12px 18px rgba(0, 0, 0, 0.38))
+    drop-shadow(0 0 12px rgba(120, 180, 255, 0.6))
+    drop-shadow(0 16px 28px rgba(120, 180, 255, 0.25));
+}
+
+.frenzy-token.is-expiring {
+  opacity: 0;
+}
+
+@keyframes frenzy-pop {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.6);
+  }
+  60% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+
 .starfield__star {
   position: absolute;
   width: 2.5px;


### PR DESCRIPTION
## Résumé
- ajoute une section de configuration pour les frénésies et expose le multiplicateur dans l’ordre de calcul
- insère une couche d’affichage et le style associés aux jetons de frénésie autour de l’atome
- implémente la logique complète des frénésies (apparitions, clics, durée d’effet, intégration aux productions et à l’UI)

## Tests
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68d05338a0b4832e8cf923a589411ae0