### PR TITLE
Add trophy system and frenzy stacking mechanics

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -59,6 +59,7 @@ const GAME_CONFIG = {
     displayDurationMs: 5000,
     effectDurationMs: 30000,
     multiplier: 2,
+    baseMaxStacks: 1,
     spawnChancePerSecond: {
       perClick: 0.01,
       perSecond: 0.01
@@ -168,6 +169,61 @@ const GAME_CONFIG = {
     {
       amount: { type: 'layer1', value: 8 },
       text: 'Accumulez 10^8 atomes pour préparer la prochaine ère.'
+    }
+  ],
+
+  /**
+   * Liste des trophées et succès spéciaux.
+   * Chaque entrée définit :
+   * - id : identifiant unique.
+   * - name / description : textes affichés dans la page Objectifs.
+   * - condition : type de condition et valeur cible.
+   * - reward : effets associés (multiplicateurs, améliorations de frénésie, etc.).
+   */
+  trophies: [
+    {
+      id: 'millionAtoms',
+      name: 'Ruée vers le million',
+      description: 'Accumulez un total d’un million d’atomes synthétisés.',
+      condition: {
+        type: 'lifetimeAtoms',
+        amount: { type: 'number', value: 1_000_000 }
+      },
+      reward: {
+        multiplier: {
+          global: 1.1
+        },
+        description: 'Boost global ×1,10 sur la production manuelle et automatique.'
+      }
+    },
+    {
+      id: 'frenzyCollector',
+      name: 'Convergence frénétique',
+      description: 'Déclenchez 100 frénésies (APC et APS cumulés).',
+      condition: {
+        type: 'frenzyTotal',
+        amount: 100
+      },
+      reward: {
+        frenzyMaxStacks: 2,
+        description: 'Débloque la frénésie multiple : deux frénésies peuvent se cumuler.'
+      }
+    },
+    {
+      id: 'frenzyMaster',
+      name: 'Tempête tri-phasée',
+      description: 'Déclenchez 1 000 frénésies cumulées.',
+      condition: {
+        type: 'frenzyTotal',
+        amount: 1_000
+      },
+      reward: {
+        frenzyMaxStacks: 3,
+        multiplier: {
+          global: 1.05
+        },
+        description: 'Active la triple frénésie et ajoute un bonus global ×1,05.'
+      }
     }
   ],
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <button class="nav-button" data-target="gacha">Gacha</button>
         <button class="nav-button" data-target="tableau">Table</button>
         <button class="nav-button" data-target="info">Infos</button>
+        <button class="nav-button" data-target="goals">Goals</button>
         <button class="nav-button" data-target="options">Options</button>
       </nav>
     </div>
@@ -33,7 +34,10 @@
       </div>
       <div class="status-item status-item--right">
         <span class="status-label">APS</span>
-        <span class="status-value" id="statusAps">0</span>
+        <div class="status-value-group">
+          <span class="status-value" id="statusAps">0</span>
+          <span class="status-frenzy-indicator" id="statusApsFrenzy" hidden></span>
+        </div>
       </div>
     </div>
   </header>
@@ -174,6 +178,13 @@
           </dl>
         </article>
       </div>
+    </section>
+
+    <section id="goals" class="page" aria-labelledby="goals-title">
+      <h2 id="goals-title">Objectifs &amp; trophées</h2>
+      <p class="section-intro">Surveillez vos succès galactiques et débloquez des bonus permanents.</p>
+      <p class="goals-empty" id="goalsEmpty" hidden>Aucun trophée disponible pour le moment.</p>
+      <div class="goals-list" id="goalsList" role="list"></div>
     </section>
 
     <section id="options" class="page" aria-labelledby="options-title">

--- a/styles.css
+++ b/styles.css
@@ -112,6 +112,13 @@ body.theme-neon .app-header {
   align-items: flex-end;
 }
 
+.status-value-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  align-items: flex-end;
+}
+
 .status-label {
   font-size: clamp(0.65rem, 1vw, 0.8rem);
   letter-spacing: 0.12em;
@@ -122,6 +129,53 @@ body.theme-neon .app-header {
 .status-value {
   font-family: 'Orbitron', monospace;
   font-size: clamp(1rem, 1.8vw, 1.35rem);
+}
+
+.status-frenzy-indicator {
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(0.58rem, 0.95vw, 0.78rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #9cf3ff;
+  padding: 0.16rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(140, 220, 255, 0.45);
+  background: linear-gradient(120deg, rgba(90, 170, 255, 0.18), rgba(20, 45, 80, 0.42));
+  text-shadow: 0 0 6px rgba(120, 220, 255, 0.75), 0 0 18px rgba(60, 150, 255, 0.55);
+  box-shadow: 0 0 12px rgba(70, 170, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  animation: frenzyPulse 1.4s ease-in-out infinite;
+}
+
+.status-frenzy-indicator[hidden] {
+  display: none;
+}
+
+body.theme-light .status-frenzy-indicator {
+  color: #0e3760;
+  border-color: rgba(0, 110, 190, 0.32);
+  background: linear-gradient(120deg, rgba(160, 210, 255, 0.35), rgba(220, 240, 255, 0.65));
+  text-shadow: 0 0 10px rgba(90, 180, 255, 0.55);
+}
+
+body.theme-neon .status-frenzy-indicator {
+  color: #bffaff;
+  border-color: rgba(120, 255, 255, 0.5);
+  background: linear-gradient(140deg, rgba(120, 255, 255, 0.24), rgba(120, 120, 255, 0.32));
+  text-shadow: 0 0 12px rgba(140, 255, 255, 0.9);
+}
+
+@keyframes frenzyPulse {
+  0%, 100% {
+    box-shadow: 0 0 10px rgba(80, 190, 255, 0.35), 0 0 24px rgba(40, 120, 255, 0.2);
+    filter: saturate(1.1);
+  }
+  50% {
+    box-shadow: 0 0 18px rgba(120, 230, 255, 0.55), 0 0 40px rgba(20, 180, 255, 0.3);
+    filter: saturate(1.4);
+  }
 }
 
 .status-value--main {
@@ -1347,6 +1401,145 @@ body.theme-neon .production-breakdown__row--total {
 
 .options-reset > #resetButton {
   align-self: flex-end;
+}
+
+.goals-list {
+  display: grid;
+  gap: clamp(0.9rem, 2vw, 1.4rem);
+  margin-top: clamp(1rem, 2vw, 1.6rem);
+}
+
+.goals-empty {
+  margin-top: clamp(1rem, 2vw, 1.4rem);
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.goal-card {
+  list-style: none;
+  background: var(--card-dark);
+  border-radius: 14px;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  position: relative;
+  overflow: hidden;
+  transition: border var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.goal-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(76, 141, 255, 0.16), rgba(110, 90, 255, 0.08));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition);
+}
+
+.goal-card:hover::before {
+  opacity: 1;
+}
+
+.goal-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.goal-card__title {
+  margin: 0;
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(0.95rem, 1.6vw, 1.15rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.goal-card__status {
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(0.7rem, 1vw, 0.85rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.goal-card__description {
+  margin: 0;
+  opacity: 0.8;
+  line-height: 1.45;
+}
+
+.goal-card__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.goal-card__progress-bar {
+  height: 0.4rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.goal-card__progress-fill {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(120deg, rgba(110, 180, 255, 0.8), rgba(86, 255, 240, 0.8));
+  box-shadow: 0 0 12px rgba(90, 200, 255, 0.45);
+  transition: width 0.35s ease;
+}
+
+.goal-card__progress-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(0.65rem, 0.95vw, 0.8rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.goal-card__reward {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--accent-strong);
+}
+
+.goal-card--completed {
+  border-color: rgba(120, 220, 255, 0.5);
+  box-shadow: 0 16px 40px rgba(90, 200, 255, 0.25);
+}
+
+.goal-card--completed .goal-card__status {
+  color: var(--accent-strong);
+  opacity: 1;
+}
+
+.goal-card--completed .goal-card__progress-fill {
+  width: 100% !important;
+  background: linear-gradient(120deg, rgba(90, 255, 210, 0.9), rgba(150, 120, 255, 0.9));
+}
+
+body.theme-light .goal-card {
+  background: var(--card-light);
+  border-color: rgba(12, 16, 32, 0.08);
+}
+
+body.theme-light .goal-card__reward {
+  color: #2760c7;
+}
+
+body.theme-neon .goal-card {
+  background: var(--card-neon);
+  border-color: rgba(110, 130, 255, 0.22);
+}
+
+body.theme-neon .goal-card__reward {
+  color: #9ffaff;
 }
 
 .option-row {


### PR DESCRIPTION
## Summary
- configure new trophy definitions and frenzy stacking defaults in `game-config`
- implement trophy tracking, goals UI, and frenzy stacking logic with APS frenzy indicator
- add Goals page styling and navigation updates

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d05b602d98832ea6bbb412a5aa38b7