### PR TITLE
feat: replace shop items with full building list

### DIFF
--- a/script.js
+++ b/script.js
@@ -893,56 +893,348 @@ const FRENZY_TYPE_INFO = {
 
 const FRENZY_TYPES = ['perClick', 'perSecond'];
 
-const FALLBACK_UPGRADES = [
-  {
-    id: 'clickCore',
-    name: 'Stabilisateur de noyau',
-    description: '+1 atome par clic.',
-    category: 'click',
-    baseCost: 10,
-    costScale: 1.65,
-    effect: level => ({ clickAdd: level })
-  },
-  {
-    id: 'quantumGloves',
-    name: 'Gants quantiques',
-    description: 'Augmente les atomes par clic de 75% par niveau.',
-    category: 'click',
-    baseCost: 120,
-    costScale: 1.9,
-    effect: level => ({ clickMult: Math.pow(1.75, level) })
-  },
-  {
-    id: 'autoSynth',
-    name: 'Synthèse automatique',
-    description: 'Produit 0,5 atome par seconde et par niveau.',
-    category: 'auto',
-    baseCost: 100,
-    costScale: 1.8,
-    effect: level => ({ autoAdd: 0.5 * level })
-  },
-  {
-    id: 'reactorArray',
-    name: 'Réseau de réacteurs',
-    description: 'Multiplicateur d’APS de +35% par niveau.',
-    category: 'auto',
-    baseCost: 600,
-    costScale: 2.1,
-    effect: level => ({ autoMult: Math.pow(1.35, level) })
-  },
-  {
-    id: 'overclock',
-    name: 'Surcadence du collecteur',
-    description: 'Augmente APC et APS de 25% par niveau.',
-    category: 'hybrid',
-    baseCost: 1500,
-    costScale: 2.35,
-    effect: level => ({
-      clickMult: Math.pow(1.25, level),
-      autoMult: Math.pow(1.25, level)
-    })
+const FALLBACK_UPGRADES = (function createFallbackUpgrades() {
+  if (typeof createShopBuildingDefinitions === 'function') {
+    return createShopBuildingDefinitions();
   }
-];
+
+  const DOUBLE_THRESHOLDS = [10, 25, 50, 100, 150, 200];
+  const QUAD_THRESHOLDS = [300, 400, 500];
+
+  const computeMultiplier = level => {
+    let multiplier = 1;
+    DOUBLE_THRESHOLDS.forEach(threshold => {
+      if (level >= threshold) {
+        multiplier *= 2;
+      }
+    });
+    QUAD_THRESHOLDS.forEach(threshold => {
+      if (level >= threshold) {
+        multiplier *= 4;
+      }
+    });
+    return multiplier;
+  };
+
+  const getLevel = (context, id) => {
+    if (!context || typeof context !== 'object') {
+      return 0;
+    }
+    const value = Number(context[id] ?? 0);
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  };
+
+  const getTotal = context => {
+    if (!context || typeof context !== 'object') {
+      return 0;
+    }
+    return Object.values(context).reduce((acc, value) => {
+      const numeric = Number(value);
+      return acc + (Number.isFinite(numeric) && numeric > 0 ? numeric : 0);
+    }, 0);
+  };
+
+  return [
+    {
+      id: 'freeElectrons',
+      name: 'Électrons libres',
+      description: 'Libérez des électrons pour une production de base stable.',
+      category: 'auto',
+      baseCost: 15,
+      costScale: 1.15,
+      effect: (level = 0) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 0.1 * level * tierMultiplier;
+        const clickAdd = level >= 100 ? 0.01 * level : 0;
+        const result = { autoAdd };
+        if (clickAdd > 0) {
+          result.clickAdd = clickAdd;
+        }
+        return result;
+      }
+    },
+    {
+      id: 'physicsLab',
+      name: 'Laboratoire de Physique',
+      description: 'Des équipes de chercheurs boostent votre production atomique.',
+      category: 'auto',
+      baseCost: 100,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const acceleratorLevel = getLevel(context, 'particleAccelerator');
+        let productionMultiplier = tierMultiplier;
+        if (acceleratorLevel >= 200) {
+          productionMultiplier *= 1.2;
+        }
+        const autoAdd = level * 1 * productionMultiplier;
+        const clickBonus = Math.pow(1.05, Math.floor(level / 10));
+        return {
+          autoAdd,
+          clickMult: clickBonus
+        };
+      }
+    },
+    {
+      id: 'nuclearReactor',
+      name: 'Réacteur nucléaire',
+      description: 'Des réacteurs contrôlés libèrent une énergie colossale.',
+      category: 'auto',
+      baseCost: 1000,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const electronLevel = getLevel(context, 'freeElectrons');
+        const labLevel = getLevel(context, 'physicsLab');
+        let productionMultiplier = tierMultiplier;
+        if (electronLevel > 0) {
+          productionMultiplier *= 1 + 0.01 * Math.floor(electronLevel / 50);
+        }
+        if (labLevel >= 200) {
+          productionMultiplier *= 1.2;
+        }
+        const autoAdd = 10 * level * productionMultiplier;
+        const clickMult = level >= 150 ? 2 : 1;
+        return clickMult > 1
+          ? { autoAdd, clickMult }
+          : { autoAdd };
+      }
+    },
+    {
+      id: 'particleAccelerator',
+      name: 'Accélérateur de particules',
+      description: 'Boostez vos particules pour décupler l’APC.',
+      category: 'hybrid',
+      baseCost: 12_000,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const supercomputerLevel = getLevel(context, 'supercomputer');
+        let productionMultiplier = tierMultiplier;
+        if (supercomputerLevel >= 100) {
+          productionMultiplier *= 1.5;
+        }
+        const autoAdd = 50 * level * productionMultiplier;
+        const clickMult = Math.pow(1.02, level);
+        return { autoAdd, clickMult };
+      }
+    },
+    {
+      id: 'supercomputer',
+      name: 'Supercalculateurs',
+      description: 'Des centres de calcul quantique optimisent vos gains.',
+      category: 'auto',
+      baseCost: 200_000,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const stationLevel = getLevel(context, 'spaceStation');
+        let productionMultiplier = tierMultiplier;
+        if (stationLevel >= 300) {
+          productionMultiplier *= 2;
+        }
+        const autoAdd = 500 * level * productionMultiplier;
+        const autoMult = Math.pow(1.01, Math.floor(level / 25));
+        return autoMult > 1
+          ? { autoAdd, autoMult }
+          : { autoAdd };
+      }
+    },
+    {
+      id: 'interstellarProbe',
+      name: 'Sonde interstellaire',
+      description: 'Explorez la galaxie pour récolter toujours plus.',
+      category: 'hybrid',
+      baseCost: 5e6,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const reactorLevel = getLevel(context, 'nuclearReactor');
+        let productionMultiplier = tierMultiplier;
+        if (reactorLevel > 0) {
+          productionMultiplier *= 1 + 0.001 * reactorLevel;
+        }
+        const autoAdd = 5000 * level * productionMultiplier;
+        const clickAdd = level >= 150 ? level : 0;
+        const result = { autoAdd };
+        if (clickAdd > 0) {
+          result.clickAdd = clickAdd;
+        }
+        return result;
+      }
+    },
+    {
+      id: 'spaceStation',
+      name: 'Station spatiale',
+      description: 'Des bases orbitales coordonnent votre expansion.',
+      category: 'hybrid',
+      baseCost: 1e8,
+      costScale: 1.15,
+      effect: (level = 0) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 50_000 * level * tierMultiplier;
+        const clickMult = Math.pow(1.05, level);
+        return { autoAdd, clickMult };
+      }
+    },
+    {
+      id: 'starForge',
+      name: 'Forgeron d’étoiles',
+      description: 'Façonnez des étoiles et dopez votre APC.',
+      category: 'hybrid',
+      baseCost: 5e10,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const stationLevel = getLevel(context, 'spaceStation');
+        let productionMultiplier = tierMultiplier;
+        if (stationLevel > 0) {
+          productionMultiplier *= 1 + 0.02 * stationLevel;
+        }
+        const autoAdd = 500_000 * level * productionMultiplier;
+        const clickMult = level >= 150 ? 1.25 : 1;
+        return clickMult > 1
+          ? { autoAdd, clickMult }
+          : { autoAdd };
+      }
+    },
+    {
+      id: 'artificialGalaxy',
+      name: 'Galaxie artificielle',
+      description: 'Ingénierie galactique pour une expansion sans fin.',
+      category: 'auto',
+      baseCost: 1e13,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const libraryLevel = getLevel(context, 'omniverseLibrary');
+        let productionMultiplier = tierMultiplier;
+        if (libraryLevel >= 300) {
+          productionMultiplier *= 2;
+        }
+        const autoAdd = 5e6 * level * productionMultiplier;
+        const autoMult = Math.pow(1.1, level);
+        const clickMult = level >= 100 ? 1.5 : 1;
+        const result = { autoAdd };
+        if (autoMult > 1) {
+          result.autoMult = autoMult;
+        }
+        if (clickMult > 1) {
+          result.clickMult = clickMult;
+        }
+        return result;
+      }
+    },
+    {
+      id: 'multiverseSimulator',
+      name: 'Simulateur de Multivers',
+      description: 'Simulez l’infini pour optimiser chaque seconde.',
+      category: 'auto',
+      baseCost: 1e16,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 5e8 * level * tierMultiplier;
+        const totalBuildings = getTotal(context);
+        const autoMult = totalBuildings > 0 ? Math.pow(1.005, totalBuildings) : 1;
+        return autoMult > 1
+          ? { autoAdd, autoMult }
+          : { autoAdd };
+      }
+    },
+    {
+      id: 'realityWeaver',
+      name: 'Tisseur de Réalité',
+      description: 'Tissez les lois physiques à votre avantage.',
+      category: 'hybrid',
+      baseCost: 1e20,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const totalBuildings = getTotal(context);
+        const autoAdd = 1e10 * level * tierMultiplier;
+        const clickAdd = totalBuildings > 0 ? 0.1 * totalBuildings * level : 0;
+        const globalMult = level >= 300 ? 2 : 1;
+        const result = { autoAdd };
+        if (clickAdd > 0) {
+          result.clickAdd = clickAdd;
+        }
+        if (globalMult > 1) {
+          result.autoMult = globalMult;
+          result.clickMult = globalMult;
+        }
+        return result;
+      }
+    },
+    {
+      id: 'cosmicArchitect',
+      name: 'Architecte Cosmique',
+      description: 'Réécrivez les plans du cosmos pour réduire les coûts.',
+      category: 'hybrid',
+      baseCost: 1e25,
+      costScale: 1.15,
+      effect: (level = 0) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 1e12 * level * tierMultiplier;
+        const clickMult = level >= 150 ? 1.2 : 1;
+        return clickMult > 1
+          ? { autoAdd, clickMult }
+          : { autoAdd };
+      }
+    },
+    {
+      id: 'parallelUniverse',
+      name: 'Univers parallèle',
+      description: 'Expérimentez des réalités alternatives à haut rendement.',
+      category: 'auto',
+      baseCost: 1e30,
+      costScale: 1.15,
+      effect: (level = 0) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 1e14 * level * tierMultiplier;
+        return { autoAdd };
+      }
+    },
+    {
+      id: 'omniverseLibrary',
+      name: 'Bibliothèque de l’Omnivers',
+      description: 'Compilez le savoir infini pour booster toute production.',
+      category: 'hybrid',
+      baseCost: 1e36,
+      costScale: 1.15,
+      effect: (level = 0, context = {}) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 1e16 * level * tierMultiplier;
+        const parallelLevel = getLevel(context, 'parallelUniverse');
+        const globalBoost = parallelLevel > 0 ? Math.pow(1.02, parallelLevel) : 1;
+        if (globalBoost > 1) {
+          return {
+            autoAdd,
+            autoMult: globalBoost,
+            clickMult: globalBoost
+          };
+        }
+        return { autoAdd };
+      }
+    },
+    {
+      id: 'quantumOverseer',
+      name: 'Grand Ordonnateur Quantique',
+      description: 'Ordonnez le multivers et atteignez la singularité.',
+      category: 'hybrid',
+      baseCost: 1e42,
+      costScale: 1.15,
+      effect: (level = 0) => {
+        const tierMultiplier = computeMultiplier(level);
+        const autoAdd = 1e18 * level * tierMultiplier;
+        const globalMult = level >= 100 ? 2 : 1;
+        return globalMult > 1
+          ? { autoAdd, autoMult: globalMult, clickMult: globalMult }
+          : { autoAdd };
+      }
+    }
+  ];
+})();
 
 const FALLBACK_MILESTONES = [
   { amount: 100, text: 'Collectez 100 atomes pour débloquer la synthèse automatique.' },
@@ -1508,14 +1800,8 @@ const UPGRADE_DEFS = Array.isArray(CONFIG.upgrades) ? CONFIG.upgrades : FALLBACK
 const UPGRADE_NAME_MAP = new Map(UPGRADE_DEFS.map(def => [def.id, def.name || def.id]));
 
 const PRODUCTION_MULTIPLIER_SLOT_MAP = {
-  perClick: new Map([
-    ['quantumGloves', 'shopBonus1'],
-    ['overclock', 'shopBonus2']
-  ]),
-  perSecond: new Map([
-    ['reactorArray', 'shopBonus1'],
-    ['overclock', 'shopBonus2']
-  ])
+  perClick: new Map(),
+  perSecond: new Map()
 };
 
 const PRODUCTION_MULTIPLIER_SLOT_FALLBACK = {
@@ -1525,12 +1811,12 @@ const PRODUCTION_MULTIPLIER_SLOT_FALLBACK = {
 
 const PRODUCTION_STEP_LABEL_OVERRIDES = {
   perClick: new Map([
-    ['shopBonus1', UPGRADE_NAME_MAP.get('quantumGloves') || 'Gants quantiques'],
-    ['shopBonus2', UPGRADE_NAME_MAP.get('overclock') || 'Surcadence du collecteur']
+    ['shopBonus1', 'Multiplicateurs APC'],
+    ['shopBonus2', 'Amplifications APC']
   ]),
   perSecond: new Map([
-    ['shopBonus1', UPGRADE_NAME_MAP.get('reactorArray') || 'Réseau de réacteurs'],
-    ['shopBonus2', UPGRADE_NAME_MAP.get('overclock') || 'Surcadence du collecteur']
+    ['shopBonus1', 'Multiplicateurs APS'],
+    ['shopBonus2', 'Amplifications APS']
   ])
 };
 
@@ -2899,9 +3185,34 @@ function gainAtoms(amount, fromClick = false) {
   evaluateTrophies();
 }
 
+function getUpgradeLevel(state, id) {
+  if (!state || typeof state !== 'object') {
+    return 0;
+  }
+  const value = Number(state[id] ?? 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function computeGlobalCostModifier(defId) {
+  let modifier = 1;
+  const architectLevel = getUpgradeLevel(gameState.upgrades, 'cosmicArchitect');
+  if (architectLevel > 0) {
+    modifier *= Math.pow(0.99, architectLevel);
+  }
+  const simulatorLevel = getUpgradeLevel(gameState.upgrades, 'multiverseSimulator');
+  if (simulatorLevel >= 200) {
+    modifier *= 0.95;
+  }
+  if (!Number.isFinite(modifier) || modifier <= 0) {
+    modifier = 0.05;
+  }
+  return Math.max(0.05, modifier);
+}
+
 function computeUpgradeCost(def) {
-  const level = gameState.upgrades[def.id] || 0;
-  const costValue = def.baseCost * Math.pow(def.costScale, level);
+  const level = getUpgradeLevel(gameState.upgrades, def.id);
+  const baseScale = def.costScale ?? 1;
+  const costValue = def.baseCost * Math.pow(baseScale, level) * computeGlobalCostModifier(def.id);
   return new LayeredNumber(costValue);
 }
 
@@ -2946,9 +3257,9 @@ function recalcProduction() {
     : toMultiplierLayered(trophyEffects.autoMultiplier ?? 1);
 
   UPGRADE_DEFS.forEach(def => {
-    const level = gameState.upgrades[def.id] || 0;
+    const level = getUpgradeLevel(gameState.upgrades, def.id);
     if (!level) return;
-    const effects = def.effect(level);
+    const effects = def.effect(level, gameState.upgrades);
 
     if (effects.clickAdd != null) {
       const value = new LayeredNumber(effects.clickAdd);
@@ -3116,7 +3427,7 @@ function updateShopAffordability() {
   UPGRADE_DEFS.forEach(def => {
     const row = shopRows.get(def.id);
     if (!row) return;
-    const level = gameState.upgrades[def.id] || 0;
+    const level = getUpgradeLevel(gameState.upgrades, def.id);
     const cost = computeUpgradeCost(def);
     const affordable = gameState.atoms.compare(cost) >= 0;
     const actionLabel = level > 0 ? 'Améliorer' : 'Acheter';


### PR DESCRIPTION
## Summary
- replace the five legacy shop upgrades with the fifteen building definitions from the new progression plan
- add helper utilities to compute building tier bonuses, synergies, and global cost modifiers consumed by both config and fallback data
- update production calculations and UI labels to handle the expanded shop multipliers and dynamic discounts

## Testing
- node -e "require('./game-config.js')"

------
https://chatgpt.com/codex/tasks/task_e_68d07543aa18832e8af36074852b7ffe