### PR TITLE
Add APC frenzy indicator and ticket-based gacha rewards

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -580,7 +580,7 @@ const GAME_CONFIG = {
   ],
 
   gacha: {
-    cost: 100,
+    ticketCost: 1, // Nombre de tickets requis par tirage
     rarities: [
       {
         id: 'commun',
@@ -625,6 +625,20 @@ const GAME_CONFIG = {
         color: '#a579ff'
       }
     ]
+  },
+
+  /**
+   * Apparition de l'étoile à tickets sur la page principale.
+   * - averageSpawnIntervalSeconds : intervalle moyen entre deux apparitions.
+   * - speedPixelsPerSecond : vitesse de déplacement de l'icône.
+   * - size : taille (en pixels) du sprite.
+   * - rewardTickets : nombre de tickets octroyés par clic.
+   */
+  ticketStar: {
+    averageSpawnIntervalSeconds: 60,
+    speedPixelsPerSecond: 90,
+    size: 72,
+    rewardTickets: 1
   },
 
   elements: [

--- a/index.html
+++ b/index.html
@@ -26,7 +26,10 @@
     <div class="status-bar" aria-live="polite">
       <div class="status-item status-item--left">
         <span class="status-label">APC</span>
-        <span class="status-value" id="statusApc">1</span>
+        <div class="status-value-group status-value-group--left">
+          <span class="status-value" id="statusApc">1</span>
+          <span class="status-frenzy-indicator" id="statusApcFrenzy" hidden></span>
+        </div>
       </div>
       <div class="status-item status-item--center">
         <span class="status-label">Atoms</span>
@@ -51,6 +54,7 @@
           <img src="Assets/Image/Atom.png" alt="Illustration d'un atome vibrant" class="atom-image" draggable="false" />
         </span>
       </button>
+      <div class="ticket-layer" id="ticketLayer" aria-hidden="true"></div>
       <div class="frenzy-layer" id="frenzyLayer" aria-hidden="true"></div>
     </section>
 
@@ -66,9 +70,9 @@
           <header class="gacha-card__header">
             <h2 id="gacha-title">Gacha</h2>
           </header>
-          <p class="gacha-wallet" id="gachaWallet">Solde : 0 atomes</p>
-          <p class="gacha-cost">Coût d'une synthèse : <span id="gachaCostValue">100</span> atomes</p>
-          <button class="gacha-roll-button" id="gachaRollButton" type="button">Lancer une synthèse</button>
+          <p class="gacha-wallet" id="gachaWallet">Solde : 0 ticket</p>
+          <p class="gacha-cost">Coût d'un tirage : <span id="gachaCostValue">1 ticket</span></p>
+          <button class="gacha-roll-button" id="gachaRollButton" type="button">Lancer un tirage</button>
           <p class="gacha-result" id="gachaResult" aria-live="polite">En attente de la prochaine transmutation.</p>
         </article>
 

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,11 @@ body.theme-neon .app-header {
   align-items: flex-end;
 }
 
+.status-value-group--left {
+  align-items: flex-start;
+  text-align: left;
+}
+
 .status-label {
   font-size: clamp(0.65rem, 1vw, 0.8rem);
   letter-spacing: 0.12em;
@@ -850,6 +855,46 @@ body.theme-neon .page--void {
   position: absolute;
   inset: 0;
   z-index: 3;
+  pointer-events: none;
+}
+
+.ticket-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.ticket-star {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: var(--ticket-star-size, clamp(52px, 9vw, 96px));
+  height: var(--ticket-star-size, clamp(52px, 9vw, 96px));
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  transform: translate(0, 0);
+  transition: transform 0.18s ease, filter 0.18s ease;
+  will-change: transform;
+  pointer-events: auto;
+}
+
+.ticket-star:hover {
+  filter: drop-shadow(0 0 12px rgba(255, 210, 120, 0.65));
+}
+
+.ticket-star:focus-visible {
+  outline: 2px solid rgba(255, 230, 150, 0.9);
+  outline-offset: 4px;
+}
+
+.ticket-star img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- add an APC frenzy countdown indicator alongside the existing APS display
- switch the gacha system to consume configurable draw tickets and persist the new currency
- spawn a configurable bouncing star on the main page that awards gacha tickets when collected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d090471e70832ea3b2e1fe90bb4bfa