### PR TITLE
Implement manual click critical hit system

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -425,12 +425,18 @@ const GAME_CONFIG = {
    * - basePerSecond : production passive initiale (0 si aucune production automatique).
    * - offlineCapSeconds : durée maximale (en secondes) prise en compte pour les gains hors-ligne.
    * - defaultTheme : thème visuel utilisé lors d'une nouvelle partie ou après réinitialisation.
+   * - crit : paramètres initiaux des coups critiques (chance, multiplicateur et plafond).
    */
   progression: {
     basePerClick: { type: 'number', value: 1 },
     basePerSecond: { type: 'number', value: 0 },
     offlineCapSeconds: 60 * 60 * 12,
-    defaultTheme: 'dark'
+    defaultTheme: 'dark',
+    crit: {
+      baseChance: 0.05,
+      baseMultiplier: 2,
+      maxMultiplier: 100
+    }
   },
 
   /**

--- a/styles.css
+++ b/styles.css
@@ -1012,6 +1012,7 @@ body.theme-neon .page--void {
 .atom-button {
   --glow-strength: 0;
   --glow-color: 255, 236, 170;
+  --critical-flash: 0;
   position: relative;
   display: block;
   width: clamp(110px, 24vw, 180px);
@@ -1038,9 +1039,11 @@ body.theme-neon .page--void {
 
 .atom-button::before {
   background: radial-gradient(circle, rgba(var(--glow-color), calc(0.42 + 0.52 * var(--glow-strength))) 0%, rgba(var(--glow-color), calc(0.22 + 0.45 * var(--glow-strength))) 42%, rgba(var(--glow-color), 0) 72%);
-  filter: blur(calc(22px + 96px * var(--glow-strength)));
+  filter:
+    blur(calc(22px + 96px * var(--glow-strength)))
+    brightness(calc(1 + 0.35 * var(--critical-flash)));
   opacity: calc(0.52 + 0.48 * var(--glow-strength));
-  transform: scale(calc(0.85 + 0.6 * var(--glow-strength)));
+  transform: scale(calc(0.85 + 0.6 * var(--glow-strength) + 0.1 * var(--critical-flash)));
   mix-blend-mode: screen;
 }
 
@@ -1049,11 +1052,47 @@ body.theme-neon .page--void {
   box-shadow:
     0 0 calc(40px + 90px * var(--glow-strength)) rgba(var(--glow-color), calc(0.24 + 0.5 * var(--glow-strength))),
     0 0 calc(80px + 140px * var(--glow-strength)) rgba(var(--glow-color), calc(0.12 + 0.35 * var(--glow-strength)));
-  opacity: calc(0.45 + 0.45 * var(--glow-strength));
+  opacity: calc(0.45 + 0.45 * var(--glow-strength) + 0.2 * var(--critical-flash));
+  filter: brightness(calc(1 + 0.25 * var(--critical-flash)));
 }
 
 .atom-button.is-pressed {
   transform: scale(0.97);
+}
+
+.atom-button.is-critical {
+  --critical-flash: 1;
+}
+
+.atom-button__crit {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -20%) scale(0.9);
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(0.95rem, 2.3vw, 1.4rem);
+  color: #ffecc2;
+  text-shadow:
+    0 0 12px rgba(255, 214, 134, 0.85),
+    0 0 26px rgba(255, 120, 54, 0.6);
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  animation: atom-critical-pop 0.6s ease-out forwards;
+}
+
+@keyframes atom-critical-pop {
+  0% {
+    transform: translate(-50%, -10%) scale(0.8);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -140%) scale(1.08);
+    opacity: 0;
+  }
 }
 
 .atom-visual {


### PR DESCRIPTION
## Summary
- add configurable defaults for manual click critical chance, multiplier and cap
- track critical modifiers during production and apply them to manual clicks
- display critical feedback on the atom button with a transient multiplier badge

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d098b85a9c832e9bd1172294e7a960