### PR TITLE
Shrink crit confetti and remove drop shadows

### DIFF
--- a/script.js
+++ b/script.js
@@ -2427,7 +2427,8 @@ const elements = {
   infoSessionDuration: document.getElementById('infoSessionDuration'),
   infoGlobalAtoms: document.getElementById('infoGlobalAtoms'),
   infoGlobalClicks: document.getElementById('infoGlobalClicks'),
-  infoGlobalDuration: document.getElementById('infoGlobalDuration')
+  infoGlobalDuration: document.getElementById('infoGlobalDuration'),
+  critConfettiLayer: null
 };
 
 const SHOP_PURCHASE_AMOUNTS = [1, 10, 100];
@@ -3645,37 +3646,110 @@ function initStarfield() {
   elements.starfield.appendChild(fragment);
 }
 
-function formatCriticalMultiplier(multiplier) {
-  const numeric = Number(multiplier);
-  if (!Number.isFinite(numeric) || numeric <= 0) {
-    return '×1';
+const CRIT_CONFETTI_COLORS = [
+  '#ff8ba7', '#ffd166', '#6fffe9', '#a5b4ff', '#ff9ff3',
+  '#70d6ff', '#fcd5ce', '#caffbf', '#bdb2ff', '#ffe066'
+];
+
+const CRIT_CONFETTI_SHAPES = [
+  { className: 'crit-confetti--circle', widthFactor: 1, heightFactor: 1 },
+  { className: 'crit-confetti--oval', widthFactor: 1.4, heightFactor: 1 },
+  { className: 'crit-confetti--heart', widthFactor: 1.1, heightFactor: 1.1 },
+  { className: 'crit-confetti--star', widthFactor: 1.2, heightFactor: 1.2 },
+  { className: 'crit-confetti--square', widthFactor: 1, heightFactor: 1 },
+  { className: 'crit-confetti--triangle', widthFactor: 1.15, heightFactor: 1.3 },
+  { className: 'crit-confetti--rectangle', widthFactor: 1.8, heightFactor: 0.7 },
+  { className: 'crit-confetti--hexagon', widthFactor: 1.1, heightFactor: 1 }
+];
+
+function ensureCritConfettiLayer() {
+  if (elements.critConfettiLayer && elements.critConfettiLayer.isConnected) {
+    return elements.critConfettiLayer;
   }
-  const value = Math.max(1, numeric);
-  let maximumFractionDigits = 2;
-  if (value >= 50) {
-    maximumFractionDigits = 0;
-  } else if (value >= 10) {
-    maximumFractionDigits = 1;
+  const layer = document.createElement('div');
+  layer.className = 'crit-confetti-layer';
+  layer.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(layer);
+  elements.critConfettiLayer = layer;
+  return layer;
+}
+
+function pickRandom(array) {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+function createCritConfettiNode() {
+  const confetti = document.createElement('span');
+  const baseSize = (12 + Math.random() * 18) * 0.1;
+  const shape = pickRandom(CRIT_CONFETTI_SHAPES);
+  const width = baseSize * shape.widthFactor;
+  const height = baseSize * shape.heightFactor;
+  confetti.className = `crit-confetti ${shape.className}`;
+  confetti.style.width = `${width.toFixed(2)}px`;
+  confetti.style.height = `${height.toFixed(2)}px`;
+
+  const startX = Math.random() * 100;
+  const startY = Math.random() * 100;
+  confetti.style.left = `${startX.toFixed(2)}%`;
+  confetti.style.top = `${startY.toFixed(2)}%`;
+
+  const driftX = (Math.random() - 0.5) * 200;
+  const driftY = 80 + Math.random() * 140;
+  const endX = driftX + (Math.random() - 0.5) * 120;
+  const endY = driftY + 60 + Math.random() * 90;
+
+  const rotationStart = Math.random() * 360;
+  const rotationEnd = rotationStart + (Math.random() * 220 - 110);
+  const spin = 50 + Math.random() * 160;
+  const scale = 0.85 + Math.random() * 0.55;
+  const duration = 2.8 + Math.random() * 0.5;
+  const delay = Math.random() * 0.25;
+
+  confetti.style.setProperty('--confetti-drift-x', `${driftX.toFixed(2)}px`);
+  confetti.style.setProperty('--confetti-drift-y', `${driftY.toFixed(2)}px`);
+  confetti.style.setProperty('--confetti-end-x', `${endX.toFixed(2)}px`);
+  confetti.style.setProperty('--confetti-end-y', `${endY.toFixed(2)}px`);
+  confetti.style.setProperty('--confetti-rotation', `${rotationStart.toFixed(2)}deg`);
+  confetti.style.setProperty('--confetti-end-rotation', `${rotationEnd.toFixed(2)}deg`);
+  confetti.style.setProperty('--confetti-spin', `${spin.toFixed(2)}deg`);
+  confetti.style.setProperty('--confetti-scale', scale.toFixed(3));
+  confetti.style.setProperty('--confetti-duration', `${duration.toFixed(2)}s`);
+  confetti.style.setProperty('--confetti-delay', `${delay.toFixed(2)}s`);
+
+  const colorA = pickRandom(CRIT_CONFETTI_COLORS);
+  let colorB = pickRandom(CRIT_CONFETTI_COLORS);
+  if (colorA === colorB) {
+    colorB = pickRandom(CRIT_CONFETTI_COLORS);
   }
-  return `×${value.toLocaleString('fr-FR', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits
-  })}`;
+  const gradientAngle = Math.floor(Math.random() * 360);
+  confetti.style.background = `linear-gradient(${gradientAngle}deg, ${colorA}, ${colorB})`;
+
+  confetti.style.setProperty('--confetti-lifetime', (duration + delay).toFixed(2));
+
+  return confetti;
 }
 
 function showCriticalIndicator(multiplier) {
-  if (!elements.atomButton) return;
-  const button = elements.atomButton;
-  button.querySelectorAll('.atom-button__crit').forEach(node => node.remove());
-  const indicator = document.createElement('span');
-  indicator.className = 'atom-button__crit';
-  indicator.textContent = formatCriticalMultiplier(multiplier);
-  button.appendChild(indicator);
-  setTimeout(() => {
-    if (indicator.isConnected) {
-      indicator.remove();
-    }
-  }, 650);
+  const layer = ensureCritConfettiLayer();
+  if (!layer) return;
+  const safeMultiplier = Math.max(1, Number(multiplier) || 1);
+  const baseCount = 26;
+  const extraCount = Math.min(42, Math.round((safeMultiplier - 1) * 8));
+  const totalConfetti = baseCount + extraCount;
+  const fragment = document.createDocumentFragment();
+
+  for (let i = 0; i < totalConfetti; i += 1) {
+    const confetti = createCritConfettiNode();
+    fragment.appendChild(confetti);
+    const lifetime = Number(confetti.style.getPropertyValue('--confetti-lifetime')) || 3;
+    setTimeout(() => {
+      if (confetti.isConnected) {
+        confetti.remove();
+      }
+    }, (lifetime + 0.3) * 1000);
+  }
+
+  layer.appendChild(fragment);
 }
 
 function applyCriticalHit(baseAmount) {

--- a/styles.css
+++ b/styles.css
@@ -1064,34 +1064,87 @@ body.theme-neon .page--void {
   --critical-flash: 1;
 }
 
-.atom-button__crit {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -20%) scale(0.9);
-  font-family: 'Orbitron', sans-serif;
-  font-size: clamp(0.95rem, 2.3vw, 1.4rem);
-  color: #ffecc2;
-  text-shadow:
-    0 0 12px rgba(255, 214, 134, 0.85),
-    0 0 26px rgba(255, 120, 54, 0.6);
-  opacity: 0;
+.crit-confetti-layer {
+  position: fixed;
+  inset: 0;
   pointer-events: none;
-  white-space: nowrap;
-  animation: atom-critical-pop 0.6s ease-out forwards;
+  overflow: hidden;
+  z-index: 40;
 }
 
-@keyframes atom-critical-pop {
+.crit-confetti {
+  position: absolute;
+  display: block;
+  transform: translate(-50%, -50%) scale(var(--confetti-scale, 1)) rotate(var(--confetti-rotation, 0deg));
+  opacity: 0;
+  border-radius: 0.35rem;
+  background-size: 140% 140%;
+  background-position: center;
+  animation: crit-confetti-float var(--confetti-duration, 3s) ease-in-out forwards;
+  animation-delay: var(--confetti-delay, 0s);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.crit-confetti--circle {
+  border-radius: 50%;
+}
+
+.crit-confetti--oval {
+  border-radius: 48% / 70%;
+}
+
+.crit-confetti--heart {
+  border-radius: 0;
+  clip-path: polygon(50% 14%, 61% 0, 78% 0, 93% 14%, 100% 32%, 95% 52%, 78% 74%, 50% 100%, 22% 74%, 5% 52%, 0 32%, 7% 14%, 22% 0, 39% 0);
+}
+
+.crit-confetti--star {
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 62% 35%, 100% 38%, 70% 60%, 82% 100%, 50% 78%, 18% 100%, 30% 60%, 0% 38%, 38% 35%);
+}
+
+.crit-confetti--square {
+  border-radius: 0.2rem;
+}
+
+.crit-confetti--triangle {
+  border-radius: 0;
+  clip-path: polygon(50% 6%, 0% 100%, 100% 100%);
+}
+
+.crit-confetti--rectangle {
+  border-radius: 0.45rem;
+}
+
+.crit-confetti--hexagon {
+  border-radius: 0;
+  clip-path: polygon(25% 6.5%, 75% 6.5%, 100% 50%, 75% 93.5%, 25% 93.5%, 0% 50%);
+}
+
+@keyframes crit-confetti-float {
   0% {
-    transform: translate(-50%, -10%) scale(0.8);
     opacity: 0;
+    transform: translate(-50%, -50%) scale(var(--confetti-scale, 1)) rotate(var(--confetti-rotation, 0deg));
   }
-  20% {
+  12% {
     opacity: 1;
   }
+  68% {
+    opacity: 1;
+    transform: translate(
+      calc(-50% + var(--confetti-drift-x, 0px)),
+      calc(-50% + var(--confetti-drift-y, 0px))
+    ) scale(var(--confetti-scale, 1)) rotate(var(--confetti-end-rotation, 0deg));
+  }
   100% {
-    transform: translate(-50%, -140%) scale(1.08);
     opacity: 0;
+    transform: translate(
+      calc(-50% + var(--confetti-end-x, 0px)),
+      calc(-50% + var(--confetti-end-y, 0px))
+    ) scale(var(--confetti-scale, 1)) rotate(
+      calc(var(--confetti-end-rotation, 0deg) + var(--confetti-spin, 90deg))
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- shrink the generated crit confetti pieces to roughly one tenth their previous size for a subtler effect
- remove the drop-shadow filter from crit confetti to eliminate the harsh haloing artefact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0a00fc7c0832ebc7cc95cc0fb9d85