### PR TITLE
Amplify crit confetti and restyle status bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,13 +31,12 @@
           <span class="status-frenzy-indicator" id="statusApcFrenzy" hidden></span>
         </div>
       </div>
-      <div class="status-item status-item--center">
-        <span class="status-label">Atoms</span>
+      <div class="status-item status-item--center" aria-label="Total d'atomes">
         <span class="status-value status-value--main" id="statusAtoms">0</span>
       </div>
       <div class="status-item status-item--right">
         <span class="status-label">APS</span>
-        <div class="status-value-group">
+        <div class="status-value-group status-value-group--aps">
           <span class="status-value" id="statusAps">0</span>
           <span class="status-frenzy-indicator" id="statusApsFrenzy" hidden></span>
         </div>

--- a/script.js
+++ b/script.js
@@ -3680,7 +3680,7 @@ function pickRandom(array) {
 
 function createCritConfettiNode() {
   const confetti = document.createElement('span');
-  const baseSize = (12 + Math.random() * 18) * 0.1;
+  const baseSize = (12 + Math.random() * 18) * 0.3;
   const shape = pickRandom(CRIT_CONFETTI_SHAPES);
   const width = baseSize * shape.widthFactor;
   const height = baseSize * shape.heightFactor;

--- a/styles.css
+++ b/styles.css
@@ -17,7 +17,7 @@
   --transition: 0.2s ease;
   --header-padding-y: clamp(0.56rem, 0.896vw, 0.784rem);
   --header-padding-x: clamp(1.2rem, 2vw, 2.4rem);
-  --status-padding-y: clamp(0.63rem, 1.02vw, 0.9rem);
+  --status-padding-y: clamp(0.315rem, 0.51vw, 0.45rem);
 }
 
 * {
@@ -87,14 +87,14 @@ body.theme-neon .app-header {
   grid-template-columns: repeat(3, 1fr);
   align-items: center;
   padding: var(--status-padding-y) var(--header-padding-x);
-  gap: clamp(0.6rem, 1vw, 1rem);
+  gap: clamp(0.4rem, 0.8vw, 0.8rem);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .status-item {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.12rem;
 }
 
 .status-item--left {
@@ -113,19 +113,23 @@ body.theme-neon .app-header {
 }
 
 .status-value-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.18rem;
-  align-items: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(0.25rem, 0.6vw, 0.45rem);
+  flex-wrap: wrap;
 }
 
 .status-value-group--left {
-  align-items: flex-start;
+  justify-content: flex-start;
   text-align: left;
 }
 
+.status-value-group--aps {
+  flex-direction: row-reverse;
+}
+
 .status-label {
-  font-size: clamp(0.65rem, 1vw, 0.8rem);
+  font-size: clamp(0.55rem, 0.88vw, 0.7rem);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   opacity: 0.72;
@@ -133,16 +137,16 @@ body.theme-neon .app-header {
 
 .status-value {
   font-family: 'Orbitron', monospace;
-  font-size: clamp(1rem, 1.8vw, 1.35rem);
+  font-size: clamp(0.92rem, 1.6vw, 1.2rem);
 }
 
 .status-frenzy-indicator {
   font-family: 'Orbitron', sans-serif;
-  font-size: clamp(0.58rem, 0.95vw, 0.78rem);
+  font-size: clamp(0.55rem, 0.9vw, 0.72rem);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: #9cf3ff;
-  padding: 0.16rem 0.6rem;
+  padding: 0.14rem 0.5rem;
   border-radius: 999px;
   border: 1px solid rgba(140, 220, 255, 0.45);
   background: linear-gradient(120deg, rgba(90, 170, 255, 0.18), rgba(20, 45, 80, 0.42));
@@ -150,8 +154,9 @@ body.theme-neon .app-header {
   box-shadow: 0 0 12px rgba(70, 170, 255, 0.18);
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.22rem;
   animation: frenzyPulse 1.4s ease-in-out infinite;
+  white-space: nowrap;
 }
 
 .status-frenzy-indicator[hidden] {
@@ -184,7 +189,26 @@ body.theme-neon .status-frenzy-indicator {
 }
 
 .status-value--main {
-  font-size: clamp(1.4rem, 2.6vw, 1.95rem);
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  background: linear-gradient(120deg, #ffd166, #ff8ba7, #70d6ff, #caffbf, #bdb2ff, #ffd166);
+  background-size: 240% 240%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: statusMainSheen 8s linear infinite;
+  text-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+}
+
+@keyframes statusMainSheen {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
 body.theme-light .status-bar {


### PR DESCRIPTION
## Summary
- enlarge the critical-hit confetti by tripling their base size so the burst is more noticeable
- rearrange the APC/APS status layout so frenzy badges sit beside the values on a slimmer header bar
- remove the redundant "Atoms" label and give the main atom counter a rainbow sheen highlight

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0a6abc950832ebc841dd1d1bfe19c