### PR TITLE
Configure cosmic common bonuses from config

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -647,6 +647,25 @@ const GAME_CONFIG = {
     rewardTickets: 1
   },
 
+  elementBonuses: {
+    groups: {
+      commun: {
+        perCopy: {
+          clickAdd: 1
+        },
+        setBonus: {
+          clickAdd: 500
+        },
+        multiplier: {
+          every: 50,
+          increment: 1,
+          cap: 100,
+          targets: ['perClick', 'perSecond']
+        }
+      }
+    }
+  },
+
   elements: [
     {
       numero: 1,


### PR DESCRIPTION
## Summary
- declare the Commun cosmique per-copy, set, and multiplier bonuses directly in the shared game configuration
- parse element group bonus settings from the configuration and apply them when computing element flats and rarity multipliers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0b8b8c724832e8ba2e85201802d76