### PR TITLE
Réorganise la page infos et affiche les bonus d'éléments

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,46 +144,55 @@
           <ul id="infoApcBreakdown" class="production-breakdown" aria-label="Détail du calcul APC"></ul>
         </article>
 
-        <article class="info-card info-card--stats" aria-labelledby="info-session-title">
+        <article class="info-card info-card--stats info-card--progression" aria-labelledby="info-progress-title">
           <header class="info-card__header">
-            <h3 id="info-session-title">Session en cours</h3>
-            <p class="info-card__subtitle">Données depuis le chargement</p>
+            <h3 id="info-progress-title">Progression</h3>
+            <p class="info-card__subtitle">Session &amp; globale</p>
           </header>
-          <dl class="info-metrics">
-            <div class="info-metrics__row">
-              <dt>Atomes gagnés</dt>
-              <dd id="infoSessionAtoms">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Clics manuels</dt>
-              <dd id="infoSessionClicks">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Durée en ligne</dt>
-              <dd id="infoSessionDuration">0s</dd>
-            </div>
-          </dl>
+          <div class="info-progress-grid" role="group" aria-labelledby="info-progress-title">
+            <section class="info-progress-block" aria-labelledby="info-session-title">
+              <h4 id="info-session-title">Session</h4>
+              <dl class="info-metrics">
+                <div class="info-metrics__row">
+                  <dt>Atomes gagnés</dt>
+                  <dd id="infoSessionAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Clics manuels</dt>
+                  <dd id="infoSessionClicks">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Durée en ligne</dt>
+                  <dd id="infoSessionDuration">0s</dd>
+                </div>
+              </dl>
+            </section>
+            <section class="info-progress-block" aria-labelledby="info-global-title">
+              <h4 id="info-global-title">Globale</h4>
+              <dl class="info-metrics">
+                <div class="info-metrics__row">
+                  <dt>Atomes gagnés</dt>
+                  <dd id="infoGlobalAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Clics manuels</dt>
+                  <dd id="infoGlobalClicks">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Durée de jeu</dt>
+                  <dd id="infoGlobalDuration">0s</dd>
+                </div>
+              </dl>
+            </section>
+          </div>
         </article>
 
-        <article class="info-card info-card--stats" aria-labelledby="info-global-title">
+        <article class="info-card info-card--bonuses" aria-labelledby="info-bonus-title">
           <header class="info-card__header">
-            <h3 id="info-global-title">Progression globale</h3>
-            <p class="info-card__subtitle">Statistiques sauvegardées</p>
+            <h3 id="info-bonus-title">Bonus éléments</h3>
+            <p class="info-card__subtitle">Commun · Essentiel · Irréel</p>
           </header>
-          <dl class="info-metrics">
-            <div class="info-metrics__row">
-              <dt>Atomes gagnés</dt>
-              <dd id="infoGlobalAtoms">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Clics manuels</dt>
-              <dd id="infoGlobalClicks">0</dd>
-            </div>
-            <div class="info-metrics__row">
-              <dt>Durée de jeu</dt>
-              <dd id="infoGlobalDuration">0s</dd>
-            </div>
-          </dl>
+          <div id="infoElementBonuses" class="element-bonus-list" role="list" aria-live="polite"></div>
         </article>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -1628,6 +1628,29 @@ body.theme-neon .info-card {
   margin: 0;
 }
 
+.info-card--progression {
+  gap: clamp(1rem, 1.8vw, 1.4rem);
+}
+
+.info-progress-grid {
+  display: grid;
+  gap: clamp(0.8rem, 1.6vw, 1.4rem);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.info-progress-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.info-progress-block h4 {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  opacity: 0.7;
+}
+
 .info-metrics {
   margin: 0;
   padding: 0;
@@ -1694,6 +1717,131 @@ body.theme-neon .production-breakdown__row--total {
   letter-spacing: 0.06em;
   font-size: 0.78rem;
   opacity: 0.7;
+}
+
+.info-card--bonuses {
+  gap: clamp(1rem, 1.8vw, 1.5rem);
+}
+
+.element-bonus-list {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.8rem, 1.4vw, 1.2rem);
+}
+
+.element-bonus-card {
+  background: rgba(255,255,255,0.05);
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.08);
+  padding: clamp(0.9rem, 1.6vw, 1.1rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+body.theme-light .element-bonus-card {
+  background: rgba(12,16,32,0.05);
+  border-color: rgba(12,16,32,0.1);
+}
+
+body.theme-neon .element-bonus-card {
+  background: rgba(80, 100, 255, 0.08);
+  border-color: rgba(120, 140, 255, 0.22);
+}
+
+.element-bonus-card--complete {
+  border-color: rgba(116, 245, 198, 0.55);
+  box-shadow: 0 0 0 1px rgba(116, 245, 198, 0.25);
+}
+
+.element-bonus-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.element-bonus-card__header h4 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.element-bonus-card__status {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.12);
+}
+
+body.theme-light .element-bonus-card__status {
+  background: rgba(12,16,32,0.12);
+}
+
+.element-bonus-stats {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.element-bonus-effects {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.6rem;
+}
+
+.element-bonus-effects__item {
+  background: rgba(255,255,255,0.06);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+body.theme-light .element-bonus-effects__item {
+  background: rgba(12,16,32,0.08);
+}
+
+.element-bonus-effects__label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.65;
+}
+
+.element-bonus-effects__value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.95rem;
+}
+
+.element-bonus-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.element-bonus-tag {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.12);
+}
+
+body.theme-light .element-bonus-tag {
+  background: rgba(12,16,32,0.14);
+}
+
+.element-bonus-empty {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.55;
 }
 
 .production-breakdown__row--total .production-breakdown__label {


### PR DESCRIPTION
## Résumé
- fusionne les panneaux "session" et "progression" dans une même carte et ajoute un module dédié aux bonus d’éléments
- met en forme les nouveaux blocs d’information, les vignettes de bonus et leurs indicateurs de statut
- calcule et affiche dynamiquement les bonus par rareté (copie, set, multiplicateurs, critique) dans la page Infos

## Tests
- Aucun test automatisé

------
https://chatgpt.com/codex/tasks/task_e_68d1a0996e78832eae44834447d55c2d