### PR TITLE
Add shop bonus info panel and clarify upgrade effects

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -70,7 +70,7 @@ function createShopBuildingDefinitions() {
       name: 'Laboratoire de Physique',
       description: 'Des équipes de chercheurs boostent votre production atomique.',
       effectSummary:
-        'Production passive : +1 APS par niveau (paliers ×2/×4). Chaque 10 labos accordent +5 % d’APC global. Palier 200 : Réacteurs +20 %.',
+        'Production passive : +1 APS par niveau (paliers ×2/×4). Chaque 10 labos accordent +5 % d’APC global. Accélérateur ≥200 : Labos +20 % APS.',
       category: 'auto',
       baseCost: 100,
       costScale: 1.15,
@@ -95,7 +95,7 @@ function createShopBuildingDefinitions() {
       name: 'Réacteur nucléaire',
       description: 'Des réacteurs contrôlés libèrent une énergie colossale.',
       effectSummary:
-        'Production passive : +10 APS par niveau (bonifiée par Électrons et Labos). Palier 150 : APC global ×2. Synergie : +1 % APS des Réacteurs par 50 Électrons.',
+        'Production passive : +10 APS par niveau (+1 % par 50 Électrons, +20 % si Labos ≥200). Palier 150 : APC global ×2.',
       category: 'auto',
       baseCost: 1000,
       costScale: 1.15,
@@ -217,7 +217,7 @@ function createShopBuildingDefinitions() {
       name: 'Forgeron d’étoiles',
       description: 'Façonnez des étoiles et dopez votre APC.',
       effectSummary:
-        'Production passive : +500 000 APS par niveau (boostée par Stations). Palier 150 : +25 % APC global.',
+        'Production passive : +500 000 APS par niveau (+2 % APS par Station). Palier 150 : +25 % APC global.',
       category: 'hybrid',
       baseCost: 5e10,
       costScale: 1.15,
@@ -343,7 +343,7 @@ function createShopBuildingDefinitions() {
       name: 'Univers parallèle',
       description: 'Expérimentez des réalités alternatives à haut rendement.',
       effectSummary:
-        'Production passive : +100 000 000 000 000 APS par niveau (paliers ×2/×4). Synergie : +50 % APS/APC à chaque renaissance.',
+        'Production passive : +100 000 000 000 000 APS par niveau (paliers ×2/×4).',
       category: 'auto',
       baseCost: 1e30,
       costScale: 1.15,

--- a/index.html
+++ b/index.html
@@ -194,6 +194,19 @@
           </header>
           <div id="infoElementBonuses" class="element-bonus-list" role="list" aria-live="polite"></div>
         </article>
+
+        <article class="info-card info-card--bonuses" aria-labelledby="info-shop-bonus-title">
+          <header class="info-card__header">
+            <h3 id="info-shop-bonus-title">Bonus boutique</h3>
+            <p class="info-card__subtitle">Effets cumulés du magasin</p>
+          </header>
+          <div
+            id="infoShopBonuses"
+            class="element-bonus-list shop-bonus-list"
+            role="list"
+            aria-live="polite"
+          ></div>
+        </article>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -1754,6 +1754,18 @@ body.theme-neon .element-bonus-card {
   box-shadow: 0 0 0 1px rgba(116, 245, 198, 0.25);
 }
 
+.shop-bonus-card--inactive {
+  opacity: 0.65;
+}
+
+.shop-bonus-card--inactive .element-bonus-card__status {
+  background: rgba(255,255,255,0.08);
+}
+
+body.theme-light .shop-bonus-card--inactive .element-bonus-card__status {
+  background: rgba(12,16,32,0.12);
+}
+
 .element-bonus-card__header {
   display: flex;
   align-items: baseline;
@@ -1777,6 +1789,13 @@ body.theme-neon .element-bonus-card {
 
 body.theme-light .element-bonus-card__status {
   background: rgba(12,16,32,0.12);
+}
+
+.shop-bonus-card__summary {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  opacity: 0.75;
 }
 
 .element-bonus-stats {


### PR DESCRIPTION
## Summary
- add an Info page card listing every shop upgrade with current level, effects and live APC/APS contributions
- expose helper utilities to aggregate shop additions/multipliers for display and hook them into the existing UI update cycle
- align several upgrade descriptions with their implemented behavior and remove references to unavailable synergies

## Testing
- not run (frontend project)

------
https://chatgpt.com/codex/tasks/task_e_68d1ac7bb100832eb3ecc0088f159e4f