### PR TITLE
Ajout des bonus Forge stellaire

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -695,6 +695,32 @@ const GAME_CONFIG = {
           label: 'Essentiel planétaire · synergie orbitale'
         }
       },
+      stellaire: {
+        perCopy: {
+          uniqueClickAdd: 50,
+          duplicateClickAdd: 25,
+          label: 'Forge stellaire · fragments activés'
+        },
+        multiplier: {
+          base: 1,
+          every: 20,
+          increment: 1,
+          targets: ['perClick'],
+          label: 'Forge stellaire · intensité stellaire'
+        },
+        setBonus: {
+          requireAllUnique: true,
+          label: 'Forge stellaire · forge parfaite',
+          rarityFlatMultipliers: {
+            commun: { perClick: 2 }
+          }
+        },
+        labels: {
+          perCopy: 'Forge stellaire · fragments',
+          setBonus: 'Forge stellaire · forge parfaite',
+          multiplier: 'Forge stellaire · intensité stellaire'
+        }
+      },
       irreel: {
         crit: {
           perUnique: {

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
         <article class="info-card info-card--bonuses" aria-labelledby="info-bonus-title">
           <header class="info-card__header">
             <h3 id="info-bonus-title">Bonus éléments</h3>
-            <p class="info-card__subtitle">Commun · Essentiel · Irréel</p>
+            <p class="info-card__subtitle">Commun · Essentiel · Forge stellaire · Irréel</p>
           </header>
           <div id="infoElementBonuses" class="element-bonus-list" role="list" aria-live="polite"></div>
         </article>


### PR DESCRIPTION
## Summary
- étend la configuration des bonus d’éléments pour supporter des gains distincts par unique/doublon et des multiplicateurs plats par rareté
- applique ces nouveautés au groupe Forge stellaire (+50 APC par unique, +25 APC par doublon, +1 multiplicateur toutes les 20 copies, set complet qui double l’APC plat commun)
- adapte l’interface d’informations afin d’annoncer la nouvelle rareté suivie

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1b488f148832eb8c32f11f0eb2971