### PR TITLE
Implement mythique quantum bonus system

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -741,6 +741,14 @@ const GAME_CONFIG = {
           multiplier: 'Singularité minérale · densité extrême'
         }
       },
+      mythique: {
+        labels: {
+          setBonus: 'Mythe quantique · convergence ultime',
+          ticketBonus: 'Mythe quantique · étoile compressée',
+          offlineBonus: 'Mythe quantique · collecte persistante',
+          duplicateOverflow: 'Mythe quantique · surcharge fractale'
+        }
+      },
       irreel: {
         crit: {
           perUnique: {


### PR DESCRIPTION
## Summary
- add mythique rarity labels for quantum bonuses
- compute ticket, offline, and frenzy bonuses for the mythique set, including overflow duplicate handling
- persist and restore the new mythique bonus state while updating ticket star scheduling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1bfae63e8832e964e2817ac8ac83f