### PR TITLE
Show all rarity bonuses in info panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,9 @@
         <article class="info-card info-card--bonuses" aria-labelledby="info-bonus-title">
           <header class="info-card__header">
             <h3 id="info-bonus-title">Bonus éléments</h3>
-            <p class="info-card__subtitle">Commun · Essentiel · Forge stellaire · Irréel</p>
+            <p class="info-card__subtitle" id="infoBonusSubtitle">
+              Commun cosmique · Essentiel planétaire · Forge stellaire · Singularité minérale · Mythe quantique · Irréel
+            </p>
           </header>
           <div id="infoElementBonuses" class="element-bonus-list" role="list" aria-live="polite"></div>
         </article>

--- a/script.js
+++ b/script.js
@@ -1445,7 +1445,12 @@ configuredRarityIds.forEach(id => {
 
 const RARITY_IDS = GACHA_RARITIES.map(entry => entry.id);
 const RARITY_LABEL_MAP = new Map(GACHA_RARITIES.map(entry => [entry.id, entry.label || entry.id]));
-const INFO_BONUS_RARITIES = ['commun', 'essentiel', 'irreel'];
+const INFO_BONUS_RARITIES = RARITY_IDS.length > 0
+  ? [...RARITY_IDS]
+  : ['commun', 'essentiel', 'stellaire', 'singulier', 'mythique', 'irreel'];
+const INFO_BONUS_SUBTITLE = INFO_BONUS_RARITIES.length
+  ? INFO_BONUS_RARITIES.map(id => RARITY_LABEL_MAP.get(id) || id).join(' · ')
+  : 'Raretés indisponibles';
 
 const rawTicketStarConfig = CONFIG.ticketStar && typeof CONFIG.ticketStar === 'object'
   ? CONFIG.ticketStar
@@ -3331,6 +3336,7 @@ const elements = {
   infoGlobalAtoms: document.getElementById('infoGlobalAtoms'),
   infoGlobalClicks: document.getElementById('infoGlobalClicks'),
   infoGlobalDuration: document.getElementById('infoGlobalDuration'),
+  infoBonusSubtitle: document.getElementById('infoBonusSubtitle'),
   infoElementBonuses: document.getElementById('infoElementBonuses'),
   infoShopBonuses: document.getElementById('infoShopBonuses'),
   critConfettiLayer: null,
@@ -4865,6 +4871,9 @@ function stripBonusLabelPrefix(label, rarityLabel) {
 function renderElementBonuses() {
   const container = elements.infoElementBonuses;
   if (!container) return;
+  if (elements.infoBonusSubtitle) {
+    elements.infoBonusSubtitle.textContent = INFO_BONUS_SUBTITLE;
+  }
   container.innerHTML = '';
 
   const summaryStore = gameState.elementBonusSummary || {};


### PR DESCRIPTION
## Summary
- derive the info panel rarity list from the configured gacha rarities so every rarity renders a bonus card
- surface the complete rarity label list in the info panel subtitle for clarity

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d1c5d8c824832e83af443a0be0a9a6