### PR TITLE
Fix Essentiel planétaire per-copy APC bonus

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -676,13 +676,12 @@ const GAME_CONFIG = {
         }
       },
       essentiel: {
+        perCopy: {
+          uniqueClickAdd: 10,
+          duplicateClickAdd: 10,
+          label: 'Essentiel planétaire · récoltes essentielles'
+        },
         setBonus: [
-          {
-            clickAdd: 10,
-            minUnique: 1,
-            requireAllUnique: false,
-            label: 'Essentiel planétaire · première découverte'
-          },
           {
             clickAdd: 1000,
             requireAllUnique: true,


### PR DESCRIPTION
## Summary
- add per-copy APC bonuses for the Essentiel planétaire rarity so each unique element and duplicate grants flat APC
- keep the collection completion bonus intact while removing the redundant first-time set bonus entry

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1d1fdfbe8832eb72cb6387aa88709