### PR TITLE
Reorder million atom trophy and boost reward

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -730,11 +730,11 @@ const GAME_CONFIG = {
       },
       reward: {
         multiplier: {
-          global: 1.1
+          global: 1.5
         },
-        description: 'Boost global ×1,10 sur la production manuelle et automatique.'
+        description: 'Boost global ×1,50 sur la production manuelle et automatique.'
       },
-      order: 1000
+      order: -1
     },
     {
       id: 'frenzyCollector',


### PR DESCRIPTION
## Summary
- move the million atom trophy to the top of the lifetime atom achievement list
- increase its global production multiplier from 1.1× to 1.5× and update the reward description accordingly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d35c412dd4832e8861782bfe7030db