### PR TITLE
Add ticket star auto collect trophy

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -766,6 +766,22 @@ const GAME_CONFIG = {
         description: 'Active la triple frénésie et ajoute un bonus global ×1,05.'
       },
       order: 1020
+    },
+    {
+      id: 'ticketHarvester',
+      name: 'Collecteur d’étoiles',
+      description: 'Complétez les collections Commun cosmique et Essentiel planétaire.',
+      condition: {
+        type: 'collectionRarities',
+        rarities: ['commun', 'essentiel']
+      },
+      reward: {
+        ticketStarAutoCollect: {
+          delaySeconds: 3
+        },
+        description: 'Sur l’écran principal, les étoiles à tickets se récoltent seules après 3 secondes.'
+      },
+      order: 1030
     }
   ],
 


### PR DESCRIPTION
## Summary
- add the "Collecteur d’étoiles" trophy unlocked by finishing the Commun and Essentiel collections with an automatic ticket-star harvest reward
- extend the trophy logic, persistence, and evaluation hooks to support collection-based conditions and the new auto-collect reward
- implement the runtime logic that tracks home page visibility and ticket-star spawn time to trigger automatic collection after the configured delay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d360161708832eb2c2e1bc44d76d1c