### PR TITLE
Add offline ticket rewards system

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -623,6 +623,7 @@ const GAME_CONFIG = {
    * - basePerClick : quantité d'atomes gagnés par clic avant bonus (Layer 0 par défaut).
    * - basePerSecond : production passive initiale (0 si aucune production automatique).
    * - offlineCapSeconds : durée maximale (en secondes) prise en compte pour les gains hors-ligne.
+   * - offlineTickets : configuration des gains de tickets hors-ligne (intervalle et plafond).
    * - defaultTheme : thème visuel utilisé lors d'une nouvelle partie ou après réinitialisation.
    * - crit : paramètres initiaux des coups critiques (chance, multiplicateur et plafond).
    */
@@ -630,6 +631,10 @@ const GAME_CONFIG = {
     basePerClick: { type: 'number', value: 1 },
     basePerSecond: { type: 'number', value: 0 },
     offlineCapSeconds: 60 * 60 * 12,
+    offlineTickets: {
+      secondsPerTicket: 60 * 15,
+      capSeconds: 60 * 60 * 24
+    },
     defaultTheme: 'dark',
     crit: {
       baseChance: 0.05,


### PR DESCRIPTION
## Summary
- introduce configurable offline ticket settings with defaults for 15-minute intervals and a 24-hour cap
- persist offline ticket progress in the save file and restore it safely on load/reset
- grant gacha tickets based on offline time with rollover progress and user feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d377381b70832e9091c2015992928d