### PR TITLE
Add x10 gacha roll UI with multi-result display

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,13 +74,21 @@
     <section id="gacha" class="page page--gacha" aria-labelledby="gacha-title">
       <h2 id="gacha-title" class="visually-hidden">Portail de tirage cosmique</h2>
       <div class="gacha-ticket-counter" id="gachaTicketCounter" aria-live="polite">
-        <img
-          src="Assets/Image/ministar.png"
-          alt=""
-          class="gacha-ticket-counter__icon"
-          aria-hidden="true"
-          draggable="false"
-        />
+        <button
+          class="gacha-ticket-mode"
+          id="gachaTicketModeButton"
+          type="button"
+          aria-label="Basculer le mode de tirage (actuel : Tirage x1)"
+        >
+          <img
+            src="Assets/Image/ministar.png"
+            alt=""
+            class="gacha-ticket-counter__icon"
+            aria-hidden="true"
+            draggable="false"
+          />
+          <span class="gacha-ticket-mode__label" id="gachaTicketModeLabel">Tirage x1</span>
+        </button>
         <span class="gacha-ticket-counter__value" id="gachaTicketValue">0 ticket</span>
       </div>
       <button

--- a/styles.css
+++ b/styles.css
@@ -427,7 +427,7 @@ main {
   right: clamp(1rem, 3vw, 2rem);
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.8rem;
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
   font-size: 0.85rem;
@@ -438,6 +438,41 @@ main {
   color: rgba(255, 255, 255, 0.86);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
   backdrop-filter: blur(6px);
+}
+
+.gacha-ticket-mode {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  border-radius: 0.85rem;
+  transition: transform 0.25s ease, background 0.3s ease;
+}
+
+.gacha-ticket-mode:focus-visible {
+  outline: 2px solid rgba(255, 220, 140, 0.85);
+  outline-offset: 3px;
+}
+
+.gacha-ticket-mode:hover,
+.gacha-ticket-mode:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-2px);
+}
+
+.gacha-ticket-mode__label {
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 .gacha-ticket-counter__icon {
@@ -615,44 +650,131 @@ body.theme-neon .gacha-ticket-counter {
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.22);
   color: #ffffff;
-  font-size: clamp(1.6rem, 3.6vw, 2.6rem);
-  line-height: 1.4;
   text-align: center;
   opacity: 0;
   transform: scale(0.84);
   transition: opacity 0.5s ease, transform 0.5s ease;
-  text-shadow:
-    0 0 12px rgba(255, 255, 255, 0.6),
-    0 0 26px rgba(255, 255, 255, 0.35),
-    0 0 38px var(--rarity-color, rgba(255, 255, 255, 0.4));
   z-index: 2;
   user-select: none;
   -webkit-user-select: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 1.6rem);
 }
 
-.gacha-result__rarity {
-  display: block;
-  font-family: 'Orbitron', sans-serif;
-  font-size: clamp(0.9rem, 2.2vw, 1.2rem);
-  letter-spacing: 0.22em;
+.gacha-result__grid {
+  width: min(720px, 82vw);
+  display: grid;
+  gap: clamp(0.8rem, 2.4vw, 1.4rem);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gacha-result-card {
+  --rarity-color: rgba(255, 255, 255, 0.5);
+  position: relative;
+  padding: clamp(0.9rem, 2.2vw, 1.4rem);
+  border-radius: 20px;
+  background: linear-gradient(160deg, rgba(18, 22, 42, 0.85), rgba(8, 10, 22, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    0 18px 34px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 36px rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  text-align: center;
+  overflow: hidden;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.gacha-result-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.gacha-result-card::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(145deg, var(--rarity-color, rgba(255, 255, 255, 0.8)), transparent 72%);
+  opacity: 0.55;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.gacha-result-card:hover,
+.gacha-result-card.is-new {
+  transform: translateY(-4px);
+  box-shadow:
+    0 24px 40px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.12),
+    0 0 42px var(--rarity-color, rgba(255, 255, 255, 0.45));
+}
+
+.gacha-result-card.is-duplicate {
+  opacity: 0.92;
+}
+
+.gacha-result-card__rarity {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  margin-bottom: 0.75rem;
-  color: var(--rarity-color, #ffffff);
-  text-shadow:
-    0 0 12px rgba(255, 255, 255, 0.55),
-    0 0 22px var(--rarity-color, rgba(255, 255, 255, 0.5));
+  color: var(--rarity-color, #fefefe);
 }
 
-.gacha-result__name {
-  display: block;
+.gacha-result-card__name {
+  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.gacha-result-card__status {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.gacha-result-card__count {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.6rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
   font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), var(--rarity-color, rgba(255, 255, 255, 0.85)));
+  color: rgba(5, 8, 18, 0.9);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
 }
 
-.gacha-result__status {
-  display: block;
-  font-size: clamp(0.9rem, 2vw, 1.2rem);
-  margin-top: 0.6rem;
-  opacity: 0.8;
+.gacha-result__summary {
+  margin: 0;
+  font-size: clamp(0.85rem, 2vw, 1.05rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.gacha-result__note {
+  margin: 0;
+  font-size: clamp(0.75rem, 1.6vw, 0.9rem);
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .gacha-continue-hint {


### PR DESCRIPTION
## Summary
- add a toggle on the ticket counter to switch between single and x10 gacha rolls with updated cost handling
- render multi-roll results as a styled grid that highlights new items or rare duplicates and shows a concise summary
- adapt the confetti animation to blend the colours of all rarities obtained during the roll

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3796d9660832ea316c5cec2e43ef9