### PR TITLE
Fix shop unlock gating when devkit free shop is active

### DIFF
--- a/script.js
+++ b/script.js
@@ -9507,34 +9507,22 @@ function buildShopItem(def) {
 
 function updateShopVisibility() {
   if (!shopRows.size) return;
-  const shopFree = isDevKitShopFree();
   const unlocks = getShopUnlockSet();
 
   let visibleLimit = -1;
-  if (shopFree) {
-    visibleLimit = UPGRADE_DEFS.length - 1;
-  } else {
-    unlocks.forEach(id => {
-      const unlockIndex = UPGRADE_INDEX_MAP.get(id);
-      if (unlockIndex != null && unlockIndex > visibleLimit) {
-        visibleLimit = unlockIndex;
-      }
-    });
-    if (visibleLimit < 0 && UPGRADE_DEFS.length > 0) {
-      visibleLimit = 0;
+  unlocks.forEach(id => {
+    const unlockIndex = UPGRADE_INDEX_MAP.get(id);
+    if (unlockIndex != null && unlockIndex > visibleLimit) {
+      visibleLimit = unlockIndex;
     }
+  });
+  if (visibleLimit < 0 && UPGRADE_DEFS.length > 0) {
+    visibleLimit = 0;
   }
 
   UPGRADE_DEFS.forEach((def, index) => {
     const row = shopRows.get(def.id);
     if (!row) return;
-
-    if (shopFree) {
-      row.root.hidden = false;
-      row.root.classList.remove('shop-item--locked');
-      unlocks.add(def.id);
-      return;
-    }
 
     const shouldReveal = index <= visibleLimit;
     row.root.hidden = !shouldReveal;


### PR DESCRIPTION
## Summary
- keep shop item visibility tied to sequential unlock progression even when the devkit free-shop cheat is enabled
- simplify the visibility logic to rely on the computed unlock set instead of forcing every item visible during free-shop mode

## Testing
- Manual verification in browser (Playwright) showing only the first two buildings visible after buying the first entry with free shop enabled

------
https://chatgpt.com/codex/tasks/task_e_68d3931c0284832e8a42947488e44929