### PR TITLE
Fix shop unlock visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1596,6 +1596,11 @@ body.theme-neon .page--void {
   transition: border var(--transition), box-shadow var(--transition), background var(--transition);
 }
 
+.shop-item[hidden],
+.shop-item--locked {
+  display: none !important;
+}
+
 .shop-item--ready {
   border-color: rgba(76, 141, 255, 0.38);
   box-shadow: 0 10px 22px rgba(76, 141, 255, 0.18);


### PR DESCRIPTION
## Summary
- ensure locked shop entries stay hidden until they are unlocked by enforcing display rules for hidden shop cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d399bc1fbc832eb426a13a7fbe0083