### PR TITLE
fix: correct bonus summaries for advanced collections

### DIFF
--- a/script.js
+++ b/script.js
@@ -5371,6 +5371,13 @@ function updateElementInfoPanel(definition) {
       }
     }
 
+    if (!bonusDetails.length) {
+      const overview = getCollectionBonusOverview(rarityId);
+      if (overview.length) {
+        bonusDetails.push(...overview);
+      }
+    }
+
     if (!bonusDetails.length && rarityDef?.description) {
       bonusDetails.push(rarityDef.description);
     }
@@ -6975,6 +6982,504 @@ function formatElementTicketInterval(seconds) {
     return null;
   }
   return `Toutes les ${duration}`;
+}
+
+const COLLECTION_BONUS_OVERVIEW_CACHE = new Map();
+
+function formatSignedBonus(value, { forcePlus = true } = {}) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric === 0) {
+    return null;
+  }
+  const abs = Math.abs(numeric);
+  const options = abs >= 100
+    ? { maximumFractionDigits: 0 }
+    : abs >= 10
+      ? { maximumFractionDigits: 1 }
+      : { maximumFractionDigits: 2 };
+  const formatted = numeric.toLocaleString('fr-FR', options);
+  if (numeric > 0 && forcePlus) {
+    return `+${formatted}`;
+  }
+  return formatted;
+}
+
+function formatBonusThreshold(addConfig, context, { includeRequireAllUnique = true } = {}) {
+  if (!addConfig) return '';
+  const notes = [];
+  const { minCopies, minUnique, requireAllUnique } = addConfig;
+  if (Number.isFinite(minCopies) && minCopies > 1) {
+    const unit = minCopies === 1 ? 'copie' : 'copies';
+    notes.push(`dès ${minCopies} ${unit}`);
+  }
+  if (Number.isFinite(minUnique) && minUnique > 0) {
+    const unit = minUnique === 1 ? 'unique' : 'uniques';
+    notes.push(`minimum ${minUnique} ${unit}`);
+  }
+  if (requireAllUnique && includeRequireAllUnique) {
+    notes.push('collection complète requise');
+  }
+  return notes.length ? ` (${notes.join(' · ')})` : '';
+}
+
+function formatRarityMultiplierNotes(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return [];
+  }
+  const notes = [];
+  entries.forEach(entry => {
+    if (!entry || typeof entry !== 'object') return;
+    const rarityId = typeof entry.rarityId === 'string' ? entry.rarityId.trim() : '';
+    if (!rarityId) return;
+    const targetLabel = RARITY_LABEL_MAP.get(rarityId) || rarityId;
+    const parts = [];
+    const clickText = formatElementMultiplierDisplay(entry.perClick);
+    if (clickText && clickText !== '×1') {
+      parts.push(`APC ${clickText}`);
+    }
+    const autoText = formatElementMultiplierDisplay(entry.perSecond);
+    if (autoText && autoText !== '×1') {
+      parts.push(`APS ${autoText}`);
+    }
+    if (parts.length) {
+      notes.push(`Amplifie ${targetLabel} : ${parts.join(' · ')}`);
+    }
+  });
+  return notes;
+}
+
+function describeAddConfig(addConfig, context, options = {}) {
+  if (!addConfig) return [];
+  const {
+    clickAdd = 0,
+    autoAdd = 0,
+    uniqueClickAdd = 0,
+    uniqueAutoAdd = 0,
+    duplicateClickAdd = 0,
+    duplicateAutoAdd = 0,
+    rarityFlatMultipliers
+  } = addConfig;
+  const overrideLabel = typeof options.overrideLabel === 'string'
+    ? options.overrideLabel.trim()
+    : null;
+
+  let includeRequireAllUnique = true;
+  let baseLabel = (() => {
+    if (typeof addConfig.label === 'string' && addConfig.label.trim()) {
+      return addConfig.label.trim();
+    }
+    if (overrideLabel) {
+      return overrideLabel;
+    }
+    if (context === 'perCopy') {
+      return 'Par copie';
+    }
+    if (context === 'setBonus') {
+      if (
+        addConfig.requireAllUnique
+        && (!Number.isFinite(addConfig.minCopies) || addConfig.minCopies <= 1)
+        && (!Number.isFinite(addConfig.minUnique) || addConfig.minUnique <= 0)
+      ) {
+        includeRequireAllUnique = false;
+        return 'Collection complète';
+      }
+      return 'Bonus de collection';
+    }
+    return 'Bonus';
+  })();
+
+  const thresholdText = formatBonusThreshold(addConfig, context, { includeRequireAllUnique });
+  const effects = [];
+
+  if (Number.isFinite(clickAdd) && clickAdd !== 0) {
+    const value = formatElementFlatBonus(clickAdd);
+    if (value) {
+      effects.push(`APC +${value}`);
+    }
+  }
+  if (Number.isFinite(autoAdd) && autoAdd !== 0) {
+    const value = formatElementFlatBonus(autoAdd);
+    if (value) {
+      effects.push(`APS +${value}`);
+    }
+  }
+
+  if (Number.isFinite(uniqueClickAdd) && uniqueClickAdd !== 0) {
+    const value = formatElementFlatBonus(uniqueClickAdd);
+    if (value) {
+      effects.push(`APC +${value} par élément unique`);
+    }
+  }
+  if (Number.isFinite(uniqueAutoAdd) && uniqueAutoAdd !== 0) {
+    const value = formatElementFlatBonus(uniqueAutoAdd);
+    if (value) {
+      effects.push(`APS +${value} par élément unique`);
+    }
+  }
+
+  if (Number.isFinite(duplicateClickAdd) && duplicateClickAdd !== 0) {
+    const value = formatElementFlatBonus(duplicateClickAdd);
+    if (value) {
+      effects.push(`APC +${value} par doublon`);
+    }
+  }
+  if (Number.isFinite(duplicateAutoAdd) && duplicateAutoAdd !== 0) {
+    const value = formatElementFlatBonus(duplicateAutoAdd);
+    if (value) {
+      effects.push(`APS +${value} par doublon`);
+    }
+  }
+
+  const rarityNotes = formatRarityMultiplierNotes(rarityFlatMultipliers);
+  if (rarityNotes.length) {
+    effects.push(...rarityNotes);
+  }
+
+  if (!effects.length) {
+    return [];
+  }
+
+  const text = `${baseLabel} : ${effects.join(' · ')}`;
+  return [thresholdText ? `${text}${thresholdText}` : text];
+}
+
+function describeCritEffect(effect, scopeLabel) {
+  if (!effect) return null;
+  const parts = [];
+  if (Number.isFinite(effect.chanceSet) && effect.chanceSet > 0) {
+    const text = formatElementCritChanceBonus(effect.chanceSet);
+    if (text) {
+      parts.push(`Chance fixée à ${text}`);
+    }
+  }
+  if (Number.isFinite(effect.chanceAdd) && effect.chanceAdd !== 0) {
+    const text = formatElementCritChanceBonus(effect.chanceAdd);
+    if (text) {
+      parts.push(`Chance +${text}`);
+    }
+  }
+  if (Number.isFinite(effect.chanceMult) && effect.chanceMult !== 1 && effect.chanceMult > 0) {
+    const text = formatElementMultiplierDisplay(effect.chanceMult);
+    if (text && text !== '×1') {
+      parts.push(`Chance ${text}`);
+    }
+  }
+  if (Number.isFinite(effect.multiplierSet) && effect.multiplierSet > 0) {
+    const text = formatElementCritMultiplierBonus(effect.multiplierSet);
+    if (text) {
+      parts.push(`Multiplicateur fixé à ${text}×`);
+    }
+  }
+  if (Number.isFinite(effect.multiplierAdd) && effect.multiplierAdd !== 0) {
+    const text = formatElementCritMultiplierBonus(effect.multiplierAdd);
+    if (text) {
+      parts.push(`Multiplicateur +${text}×`);
+    }
+  }
+  if (Number.isFinite(effect.multiplierMult) && effect.multiplierMult !== 1 && effect.multiplierMult > 0) {
+    const text = formatElementMultiplierDisplay(effect.multiplierMult);
+    if (text && text !== '×1') {
+      parts.push(`Multiplicateur ${text}`);
+    }
+  }
+  if (Number.isFinite(effect.maxMultiplierSet) && effect.maxMultiplierSet > 0) {
+    const text = formatElementCritMultiplierBonus(effect.maxMultiplierSet);
+    if (text) {
+      parts.push(`Cap critique fixé à ${text}×`);
+    }
+  }
+  if (Number.isFinite(effect.maxMultiplierAdd) && effect.maxMultiplierAdd !== 0) {
+    const text = formatElementCritMultiplierBonus(effect.maxMultiplierAdd);
+    if (text) {
+      parts.push(`Cap critique +${text}×`);
+    }
+  }
+  if (Number.isFinite(effect.maxMultiplierMult) && effect.maxMultiplierMult !== 1 && effect.maxMultiplierMult > 0) {
+    const text = formatElementMultiplierDisplay(effect.maxMultiplierMult);
+    if (text && text !== '×1') {
+      parts.push(`Cap critique ${text}`);
+    }
+  }
+  return parts.length ? `${scopeLabel} : ${parts.join(' · ')}` : null;
+}
+
+function describeCritConfig(critConfig) {
+  if (!critConfig) return [];
+  const results = [];
+  if (critConfig.perUnique) {
+    const text = describeCritEffect(critConfig.perUnique, 'Critique par unique');
+    if (text) {
+      results.push(text);
+    }
+  }
+  if (critConfig.perDuplicate) {
+    const text = describeCritEffect(critConfig.perDuplicate, 'Critique par doublon');
+    if (text) {
+      results.push(text);
+    }
+  }
+  return results;
+}
+
+function describeMultiplierConfig(multiplierConfig, labelOverride = null) {
+  if (!multiplierConfig) return null;
+  const targets = [];
+  if (multiplierConfig.targets?.has('perClick')) {
+    targets.push('APC');
+  }
+  if (multiplierConfig.targets?.has('perSecond')) {
+    targets.push('APS');
+  }
+  const targetLabel = targets.length === 2
+    ? 'APC/APS'
+    : targets.length === 1
+      ? targets[0]
+      : 'production';
+  const parts = [];
+  if (
+    Number.isFinite(multiplierConfig.base)
+    && Math.abs(multiplierConfig.base - 1) > 1e-9
+  ) {
+    const baseText = formatMultiplier(multiplierConfig.base);
+    if (baseText && baseText !== '×—') {
+      const prefix = targetLabel === 'production' ? '' : `${targetLabel} `;
+      parts.push(`${prefix}base ${baseText}`.trim());
+    }
+  }
+  if (
+    Number.isFinite(multiplierConfig.increment)
+    && multiplierConfig.increment !== 0
+    && Number.isFinite(multiplierConfig.every)
+    && multiplierConfig.every > 0
+  ) {
+    const incrementText = formatSignedBonus(multiplierConfig.increment);
+    if (incrementText) {
+      const unit = multiplierConfig.every === 1 ? 'copie' : 'copies';
+      const prefix = targetLabel === 'production' ? '' : `${targetLabel} `;
+      parts.push(`${prefix}${incrementText} toutes les ${multiplierConfig.every} ${unit}`.trim());
+    }
+  }
+  if (
+    Number.isFinite(multiplierConfig.cap)
+    && multiplierConfig.cap > 0
+    && multiplierConfig.cap !== Number.POSITIVE_INFINITY
+  ) {
+    const capText = formatMultiplier(multiplierConfig.cap);
+    if (capText && capText !== '×—') {
+      const prefix = targetLabel === 'production' ? '' : `${targetLabel} `;
+      parts.push(`${prefix}max ${capText}`.trim());
+    }
+  }
+  if (!parts.length) {
+    return null;
+  }
+  const prefix = labelOverride && labelOverride.trim()
+    ? labelOverride.trim()
+    : `Multiplicateur ${targetLabel}`;
+  return `${prefix} : ${parts.join(' · ')}`;
+}
+
+function describeRarityMultiplierBonus(bonusConfig, labelOverride = null) {
+  if (!bonusConfig) return null;
+  const targets = [];
+  if (bonusConfig.targets?.has('perClick')) {
+    targets.push('APC');
+  }
+  if (bonusConfig.targets?.has('perSecond')) {
+    targets.push('APS');
+  }
+  const targetLabel = targets.length === 2
+    ? 'APC/APS'
+    : targets.length === 1
+      ? targets[0]
+      : 'production';
+  const amountText = formatSignedBonus(bonusConfig.amount);
+  if (!amountText) {
+    return null;
+  }
+  const notes = [];
+  if (Number.isFinite(bonusConfig.uniqueThreshold) && bonusConfig.uniqueThreshold > 0) {
+    const unit = bonusConfig.uniqueThreshold === 1 ? 'unique' : 'uniques';
+    notes.push(`minimum ${bonusConfig.uniqueThreshold} ${unit}`);
+  }
+  if (Number.isFinite(bonusConfig.copyThreshold) && bonusConfig.copyThreshold > 0) {
+    const unit = bonusConfig.copyThreshold === 1 ? 'copie' : 'copies';
+    notes.push(`dès ${bonusConfig.copyThreshold} ${unit}`);
+  }
+  const suffix = notes.length ? ` (${notes.join(' · ')})` : '';
+  const detail = targetLabel === 'production'
+    ? `${amountText}${suffix}`
+    : `${targetLabel} ${amountText}${suffix}`;
+  if (labelOverride && labelOverride.trim()) {
+    return `${labelOverride.trim()} : ${detail}`;
+  }
+  return `Multiplicateur de rareté ${detail}`;
+}
+
+function describeMythiqueSpecials(groupConfig) {
+  const labels = groupConfig?.labels && typeof groupConfig.labels === 'object'
+    ? groupConfig.labels
+    : {};
+  const resolveLabel = (key, fallback) => {
+    const raw = typeof labels[key] === 'string' ? labels[key].trim() : '';
+    return raw || fallback;
+  };
+  const rarityLabel = RARITY_LABEL_MAP.get(MYTHIQUE_RARITY_ID) || 'Mythe quantique';
+  const results = [];
+
+  const formatSmallNumber = value => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return null;
+    }
+    const abs = Math.abs(numeric);
+    const options = abs >= 100
+      ? { maximumFractionDigits: 0 }
+      : abs >= 10
+        ? { maximumFractionDigits: 1 }
+        : { maximumFractionDigits: 2 };
+    return numeric.toLocaleString('fr-FR', options);
+  };
+
+  if (
+    Number.isFinite(MYTHIQUE_TICKET_UNIQUE_REDUCTION_SECONDS)
+    && MYTHIQUE_TICKET_UNIQUE_REDUCTION_SECONDS > 0
+  ) {
+    const reductionText = formatSmallNumber(MYTHIQUE_TICKET_UNIQUE_REDUCTION_SECONDS);
+    const parts = [];
+    if (reductionText) {
+      parts.push(`Réduit l’intervalle des étoiles à tickets de ${reductionText}s par élément unique`);
+    }
+    if (
+      Number.isFinite(MYTHIQUE_TICKET_MIN_INTERVAL_SECONDS)
+      && MYTHIQUE_TICKET_MIN_INTERVAL_SECONDS > 0
+    ) {
+      const minText = formatSmallNumber(MYTHIQUE_TICKET_MIN_INTERVAL_SECONDS);
+      if (minText) {
+        parts.push(`minimum ${minText}s`);
+      }
+    }
+    if (parts.length) {
+      const label = resolveLabel('ticketBonus', `${rarityLabel} · accélération quantique`);
+      results.push(`${label} : ${parts.join(' · ')}`);
+    }
+  }
+
+  if (Number.isFinite(MYTHIQUE_OFFLINE_PER_DUPLICATE) && MYTHIQUE_OFFLINE_PER_DUPLICATE > 0) {
+    const parts = [];
+    if (Number.isFinite(MYTHIQUE_OFFLINE_BASE) && Math.abs(MYTHIQUE_OFFLINE_BASE - 1) > 1e-9) {
+      const baseText = formatMultiplier(MYTHIQUE_OFFLINE_BASE);
+      if (baseText && baseText !== '×—') {
+        parts.push(`base ${baseText}`);
+      }
+    }
+    const incrementText = formatSignedBonus(MYTHIQUE_OFFLINE_PER_DUPLICATE);
+    if (incrementText) {
+      parts.push(`${incrementText} par doublon`);
+    }
+    if (
+      Number.isFinite(MYTHIQUE_OFFLINE_CAP)
+      && MYTHIQUE_OFFLINE_CAP > 0
+      && MYTHIQUE_OFFLINE_CAP !== Number.POSITIVE_INFINITY
+    ) {
+      const capText = formatMultiplier(MYTHIQUE_OFFLINE_CAP);
+      if (capText && capText !== '×—') {
+        parts.push(`max ${capText}`);
+      }
+    }
+    if (parts.length) {
+      const label = resolveLabel('offlineBonus', `${rarityLabel} · collecte hors ligne`);
+      results.push(`${label} : Collecte hors ligne ${parts.join(' · ')}`);
+    }
+  }
+
+  if (
+    Number.isFinite(MYTHIQUE_DUPLICATE_OVERFLOW_FLAT_BONUS)
+    && MYTHIQUE_DUPLICATE_OVERFLOW_FLAT_BONUS !== 0
+    && Number.isFinite(MYTHIQUE_DUPLICATES_FOR_OFFLINE_CAP)
+    && MYTHIQUE_DUPLICATES_FOR_OFFLINE_CAP !== Number.POSITIVE_INFINITY
+  ) {
+    const overflowValue = formatElementFlatBonus(MYTHIQUE_DUPLICATE_OVERFLOW_FLAT_BONUS);
+    if (overflowValue) {
+      const threshold = Math.max(0, Math.floor(MYTHIQUE_DUPLICATES_FOR_OFFLINE_CAP));
+      const thresholdText = formatSmallNumber(threshold);
+      const unit = threshold <= 1 ? 'doublon' : 'doublons';
+      const parts = [`APC/APS +${overflowValue} par doublon`];
+      if (Number.isFinite(threshold) && threshold > 0 && thresholdText) {
+        parts.push(`au-delà de ${thresholdText} ${unit}`);
+      }
+      const label = resolveLabel('duplicateOverflow', `${rarityLabel} · surcharge fractale`);
+      results.push(`${label} : ${parts.join(' · ')}`);
+    }
+  }
+
+  if (
+    Number.isFinite(MYTHIQUE_FRENZY_SPAWN_BONUS_MULTIPLIER)
+    && Math.abs(MYTHIQUE_FRENZY_SPAWN_BONUS_MULTIPLIER - 1) > 1e-9
+  ) {
+    const frenzyText = formatMultiplier(MYTHIQUE_FRENZY_SPAWN_BONUS_MULTIPLIER);
+    if (frenzyText && frenzyText !== '×—') {
+      const label = resolveLabel('setBonus', `${rarityLabel} · convergence ultime`);
+      results.push(`${label} : Chance de frénésie ${frenzyText} (collection complète requise)`);
+    }
+  }
+
+  return results;
+}
+
+function getCollectionBonusOverview(rarityId) {
+  if (!rarityId) return [];
+  if (COLLECTION_BONUS_OVERVIEW_CACHE.has(rarityId)) {
+    return COLLECTION_BONUS_OVERVIEW_CACHE.get(rarityId);
+  }
+  const config = ELEMENT_GROUP_BONUS_CONFIG.get(rarityId);
+  if (!config) {
+    COLLECTION_BONUS_OVERVIEW_CACHE.set(rarityId, []);
+    return [];
+  }
+  const overview = [];
+  const labelOverrides = config.labels && typeof config.labels === 'object' ? config.labels : {};
+
+  describeAddConfig(config.perCopy, 'perCopy', { overrideLabel: labelOverrides.perCopy })
+    .forEach(text => overview.push(text));
+
+  if (Array.isArray(config.setBonuses) && config.setBonuses.length) {
+    config.setBonuses.forEach(entry => {
+      if (!entry) return;
+      const overrideLabel = (typeof entry.label === 'string' && entry.label.trim())
+        ? null
+        : labelOverrides.setBonus;
+      describeAddConfig(entry, 'setBonus', { overrideLabel })
+        .forEach(text => overview.push(text));
+    });
+  } else if (config.setBonus) {
+    const overrideLabel = (typeof config.setBonus.label === 'string' && config.setBonus.label.trim())
+      ? null
+      : labelOverrides.setBonus;
+    describeAddConfig(config.setBonus, 'setBonus', { overrideLabel })
+      .forEach(text => overview.push(text));
+  }
+
+  const multiplierLabel = config.multiplier?.label || labelOverrides.multiplier || null;
+  const multiplierText = describeMultiplierConfig(config.multiplier, multiplierLabel);
+  if (multiplierText) {
+    overview.push(multiplierText);
+  }
+
+  describeCritConfig(config.crit).forEach(text => overview.push(text));
+
+  const rarityMultiplierLabel = labelOverrides.rarityMultiplier || null;
+  const rarityMultiplierText = describeRarityMultiplierBonus(config.rarityMultiplierBonus, rarityMultiplierLabel);
+  if (rarityMultiplierText) {
+    overview.push(rarityMultiplierText);
+  }
+
+  if (rarityId === MYTHIQUE_RARITY_ID) {
+    describeMythiqueSpecials(config).forEach(text => overview.push(text));
+  }
+
+  COLLECTION_BONUS_OVERVIEW_CACHE.set(rarityId, overview);
+  return overview;
 }
 
 function stripBonusLabelPrefix(label, rarityLabel) {


### PR DESCRIPTION
## Summary
- reformat collection bonus summaries to honour rarity labels and explicitly list per-unique and per-doublon gains
- include configured names when presenting multiplier and rarity multiplier bonuses for each collection
- add a dedicated overview for mythique special effects covering tickets, offline gains, overflow flats and frenzy bonuses

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d3a39749e0832ea629faf1b96e0994