### PR TITLE
Remove progress indicators from goal cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -10240,34 +10240,13 @@ function buildGoalCard(def) {
   title.textContent = def.name;
   title.className = 'goal-card__title';
 
-  const status = document.createElement('span');
-  status.className = 'goal-card__status';
-  status.textContent = '0%';
-
-  header.append(title, status);
+  header.append(title);
 
   const description = document.createElement('p');
   description.className = 'goal-card__description';
   description.textContent = def.description || '';
 
-  const progress = document.createElement('div');
-  progress.className = 'goal-card__progress';
-
-  const bar = document.createElement('div');
-  bar.className = 'goal-card__progress-bar';
-
-  const barFill = document.createElement('span');
-  barFill.className = 'goal-card__progress-fill';
-  barFill.style.width = '0%';
-  bar.appendChild(barFill);
-
-  const progressValue = document.createElement('span');
-  progressValue.className = 'goal-card__progress-value';
-  progressValue.textContent = '0 / 0';
-
-  progress.append(bar, progressValue);
-
-  card.append(header, description, progress);
+  card.append(header, description);
 
   if (def.rewardText) {
     const reward = document.createElement('p');
@@ -10276,7 +10255,7 @@ function buildGoalCard(def) {
     card.appendChild(reward);
   }
 
-  return { root: card, status, progressValue, barFill };
+  return { root: card };
 }
 
 function renderGoals() {
@@ -10343,13 +10322,6 @@ function updateGoalsUI() {
     const card = trophyCards.get(def.id);
     if (!card) return;
     const isUnlocked = unlocked.has(def.id);
-    const progress = formatTrophyProgress(def);
-    const percent = isUnlocked ? 1 : Math.max(0, Math.min(1, progress.percent || 0));
-    card.barFill.style.width = `${(percent * 100).toFixed(0)}%`;
-    card.progressValue.textContent = isUnlocked
-      ? `✓ ${progress.displayTarget}`
-      : `${progress.displayCurrent} / ${progress.displayTarget}`;
-    card.status.textContent = isUnlocked ? 'Débloqué' : `${(percent * 100).toFixed(0)}%`;
     card.root.classList.toggle('goal-card--completed', isUnlocked);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -2422,7 +2422,7 @@ body.theme-light .element-bonus-specials__item {
   list-style: none;
   background: var(--card-dark);
   border-radius: 14px;
-  padding: clamp(1rem, 2vw, 1.5rem);
+  padding: clamp(0.5rem, 1vw, 0.75rem);
   border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   flex-direction: column;
@@ -2461,48 +2461,10 @@ body.theme-light .element-bonus-specials__item {
   text-transform: uppercase;
 }
 
-.goal-card__status {
-  font-family: 'Orbitron', sans-serif;
-  font-size: clamp(0.7rem, 1vw, 0.85rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  opacity: 0.75;
-}
-
 .goal-card__description {
   margin: 0;
   opacity: 0.8;
   line-height: 1.45;
-}
-
-.goal-card__progress {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.goal-card__progress-bar {
-  height: 0.4rem;
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.goal-card__progress-fill {
-  display: block;
-  height: 100%;
-  width: 0%;
-  background: linear-gradient(120deg, rgba(110, 180, 255, 0.8), rgba(86, 255, 240, 0.8));
-  box-shadow: 0 0 12px rgba(90, 200, 255, 0.45);
-  transition: width 0.35s ease;
-}
-
-.goal-card__progress-value {
-  font-family: 'Orbitron', sans-serif;
-  font-size: clamp(0.65rem, 0.95vw, 0.8rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  opacity: 0.75;
 }
 
 .goal-card__reward {
@@ -2515,16 +2477,6 @@ body.theme-light .element-bonus-specials__item {
 .goal-card--completed {
   border-color: rgba(120, 220, 255, 0.5);
   box-shadow: 0 16px 40px rgba(90, 200, 255, 0.25);
-}
-
-.goal-card--completed .goal-card__status {
-  color: var(--accent-strong);
-  opacity: 1;
-}
-
-.goal-card--completed .goal-card__progress-fill {
-  width: 100% !important;
-  background: linear-gradient(120deg, rgba(90, 255, 210, 0.9), rgba(150, 120, 255, 0.9));
 }
 
 body.theme-light .goal-card {


### PR DESCRIPTION
## Summary
- remove progress counters and bars from goal cards on the Goals page
- halve the padding of goal cards to make the success boxes thinner

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3bb2231f8832ebe657244c485b67d