### PR TITLE
Increase interstellar probe click bonus

### DIFF
--- a/game-config.js
+++ b/game-config.js
@@ -172,7 +172,7 @@ function createShopBuildingDefinitions() {
       name: 'Sonde interstellaire',
       description: 'Explorez la galaxie pour récolter toujours plus.',
       effectSummary:
-        'Production passive : +5 000 APS par niveau (boostée par Réacteurs). À 150 exemplaires : chaque sonde ajoute +1 APC.',
+        'Production passive : +5 000 APS par niveau (boostée par Réacteurs). À 150 exemplaires : chaque sonde ajoute +10 APC.',
       category: 'hybrid',
       baseCost: 5e6,
       costScale: 1.2,
@@ -186,7 +186,7 @@ function createShopBuildingDefinitions() {
         const baseAmount = 5000 * level;
         const rawAutoAdd = baseAmount * productionMultiplier;
         const autoAdd = level > 0 ? Math.max(baseAmount, Math.round(rawAutoAdd)) : 0;
-        const clickAdd = level >= 150 ? level : 0;
+        const clickAdd = level >= 150 ? level * 10 : 0;
         const result = { autoAdd };
         if (clickAdd > 0) {
           result.clickAdd = clickAdd;

--- a/script.js
+++ b/script.js
@@ -2404,7 +2404,7 @@ const FALLBACK_UPGRADES = (function createFallbackUpgrades() {
       name: 'Sonde interstellaire',
       description: 'Explorez la galaxie pour récolter toujours plus.',
       effectSummary:
-        'Production passive : +5 000 APS par niveau (boostée par Réacteurs). À 150 exemplaires : chaque sonde ajoute +1 APC.',
+        'Production passive : +5 000 APS par niveau (boostée par Réacteurs). À 150 exemplaires : chaque sonde ajoute +10 APC.',
       category: 'hybrid',
       baseCost: 5e6,
       costScale: 1.2,
@@ -2418,7 +2418,7 @@ const FALLBACK_UPGRADES = (function createFallbackUpgrades() {
         const baseAmount = 5000 * level;
         const rawAutoAdd = baseAmount * productionMultiplier;
         const autoAdd = level > 0 ? Math.max(baseAmount, Math.round(rawAutoAdd)) : 0;
-        const clickAdd = level >= 150 ? level : 0;
+        const clickAdd = level >= 150 ? level * 10 : 0;
         const result = { autoAdd };
         if (clickAdd > 0) {
           result.clickAdd = clickAdd;


### PR DESCRIPTION
## Summary
- raise the interstellar probe milestone description to grant +10 APC per unit after 150 copies
- update the probe effect logic so the click bonus now scales at 10 APC per level past the threshold

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3cc25b3ec832e83d0c5aabb840594