### PR TITLE
Reduce gacha result card size

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -985,10 +985,10 @@ body.theme-neon .gacha-ticket-counter {
 }
 
 .gacha-result__grid {
-  width: min(720px, 82vw);
+  width: min(576px, 82vw);
   display: grid;
-  gap: clamp(0.8rem, 2.4vw, 1.4rem);
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(0.64rem, 1.92vw, 1.12rem);
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
   margin: 0;
   padding: 0;
   list-style: none;
@@ -997,8 +997,8 @@ body.theme-neon .gacha-ticket-counter {
 .gacha-result-card {
   --rarity-color: rgba(255, 255, 255, 0.5);
   position: relative;
-  padding: clamp(0.9rem, 2.2vw, 1.4rem);
-  border-radius: 20px;
+  padding: clamp(0.72rem, 1.76vw, 1.12rem);
+  border-radius: 16px;
   background: linear-gradient(160deg, rgba(18, 22, 42, 0.85), rgba(8, 10, 22, 0.65));
   border: 1px solid rgba(255, 255, 255, 0.18);
   box-shadow:
@@ -1008,7 +1008,7 @@ body.theme-neon .gacha-ticket-counter {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.44rem;
   text-align: center;
   overflow: hidden;
   transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
@@ -1049,34 +1049,34 @@ body.theme-neon .gacha-ticket-counter {
 }
 
 .gacha-result-card__rarity {
-  font-size: 0.78rem;
-  letter-spacing: 0.14em;
+  font-size: 0.62rem;
+  letter-spacing: 0.112em;
   text-transform: uppercase;
   color: var(--rarity-color, #fefefe);
 }
 
 .gacha-result-card__name {
-  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+  font-size: clamp(0.88rem, 1.92vw, 1.2rem);
   font-weight: 600;
   letter-spacing: 0.04em;
 }
 
 .gacha-result-card__status {
-  font-size: 0.9rem;
-  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  letter-spacing: 0.064em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.78);
 }
 
 .gacha-result-card__count {
   position: absolute;
-  top: 0.55rem;
-  right: 0.6rem;
-  padding: 0.2rem 0.6rem;
+  top: 0.44rem;
+  right: 0.48rem;
+  padding: 0.16rem 0.48rem;
   border-radius: 999px;
-  font-size: 0.82rem;
+  font-size: 0.66rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.064em;
   text-transform: uppercase;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), var(--rarity-color, rgba(255, 255, 255, 0.85)));
   color: rgba(5, 8, 18, 0.9);


### PR DESCRIPTION
## Summary
- shrink the gacha result grid width and spacing to tighten the layout
- decrease result card padding, border radius, and typography to reduce card footprint by roughly 20%

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d42a6bf308832ea778b0d723b204c1