### PR TITLE
Prevent layered number recursion at higher tiers

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -269,9 +269,15 @@ class LayeredNumber {
 
     if (this.layer > b.layer) {
       const lifted = b.toLayer(this.layer);
+      if (lifted.layer !== this.layer) {
+        return this.clone();
+      }
       return this.add(lifted);
     }
     const lifted = this.toLayer(b.layer);
+    if (lifted.layer !== b.layer) {
+      return b.clone();
+    }
     return lifted.add(b);
   }
 
@@ -320,9 +326,18 @@ class LayeredNumber {
       }
     }
 
-    const higher = this.layer > b.layer ? this : this.toLayer(b.layer);
-    const lower = this.layer > b.layer ? b.toLayer(this.layer) : b;
-    return higher.subtract(lower);
+    if (this.layer > b.layer) {
+      const lifted = b.toLayer(this.layer);
+      if (lifted.layer !== this.layer) {
+        return this.clone();
+      }
+      return this.subtract(lifted);
+    }
+    const lifted = this.toLayer(b.layer);
+    if (lifted.layer !== b.layer) {
+      return b.negate().subtract(this.negate());
+    }
+    return lifted.subtract(b);
   }
 
   multiply(other) {


### PR DESCRIPTION
## Summary
- guard LayeredNumber addition against failed layer conversions so high layer saves return safely
- update subtraction fallback logic to avoid infinite recursion and mirror dominant operand when conversion fails

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d51e56c318832ea375b847da105113