### PR TITLE
Add APC and APS atom counters to info dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,18 @@
                   <dd id="infoSessionClicks">0</dd>
                 </div>
                 <div class="info-metrics__row">
+                  <dt>Atomes via APC</dt>
+                  <dd id="infoSessionApcAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Atomes via APS</dt>
+                  <dd id="infoSessionApsAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Atomes hors ligne</dt>
+                  <dd id="infoSessionOfflineAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
                   <dt>Durée en ligne</dt>
                   <dd id="infoSessionDuration">0s</dd>
                 </div>
@@ -216,6 +228,18 @@
                 <div class="info-metrics__row">
                   <dt>Clics manuels</dt>
                   <dd id="infoGlobalClicks">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Atomes via APC</dt>
+                  <dd id="infoGlobalApcAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Atomes via APS</dt>
+                  <dd id="infoGlobalApsAtoms">0</dd>
+                </div>
+                <div class="info-metrics__row">
+                  <dt>Atomes hors ligne</dt>
+                  <dd id="infoGlobalOfflineAtoms">0</dd>
                 </div>
                 <div class="info-metrics__row">
                   <dt>Durée de jeu</dt>


### PR DESCRIPTION
## Summary
- add APC/APS/offline atom counters to the info page for both the session and global sections
- track atom gains from APC, APS, and offline production in the saved stats so the counters stay current

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5944931fc832eb8e4b55fd3c2de96