### PR TITLE
Simplifie les encarts de rareté dans les infos

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -8604,14 +8604,12 @@ function renderElementBonuses() {
     title.textContent = summary.label;
     header.appendChild(title);
 
-    const status = document.createElement('span');
-    status.className = 'element-bonus-card__status';
     if (summaryType === 'family') {
+      const status = document.createElement('span');
+      status.className = 'element-bonus-card__status';
       status.textContent = summary.isComplete ? 'Famille complète' : 'Famille en cours';
-    } else {
-      status.textContent = summary.isComplete ? 'Complet' : 'En cours';
+      header.appendChild(status);
     }
-    header.appendChild(status);
 
     meta.appendChild(header);
 
@@ -8638,16 +8636,12 @@ function renderElementBonuses() {
     const copiesCount = Number(summary.copies || 0);
     const uniqueCount = Number(summary.uniques || 0);
     const totalUnique = Number(summary.totalUnique || 0);
-    const activeCopies = Math.max(0, Number(summary.activeCopies || 0));
-
     const uniqueDisplay = totalUnique > 0
       ? `${uniqueCount.toLocaleString('fr-FR')} / ${totalUnique.toLocaleString('fr-FR')}`
       : uniqueCount.toLocaleString('fr-FR');
 
     addCountRow('Éléments uniques', uniqueDisplay);
-    const lifetimeDisplay = copiesCount.toLocaleString('fr-FR');
-    const activeDisplay = activeCopies.toLocaleString('fr-FR');
-    addCountRow('Copies totales', `${lifetimeDisplay} · Actives ${activeDisplay}`);
+    addCountRow('Total', copiesCount.toLocaleString('fr-FR'));
 
     if (counts.children.length) {
       meta.appendChild(counts);
@@ -8835,7 +8829,7 @@ function renderElementBonuses() {
       section.appendChild(tags);
       details.appendChild(section);
     }
-    if (specialEntries.length) {
+    if (specialEntries.length && summary.rarityId !== 'mythique') {
       const section = document.createElement('section');
       section.className = 'element-bonus-section';
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -2273,10 +2273,10 @@ body.theme-neon .production-breakdown__row--total {
   background: rgba(255,255,255,0.05);
   border-radius: 14px;
   border: 1px solid rgba(255,255,255,0.08);
-  padding: clamp(0.65rem, 1.2vw, 0.95rem) clamp(0.8rem, 1.6vw, 1.2rem);
+  padding: clamp(0.35rem, 0.8vw, 0.55rem) clamp(0.5rem, 1vw, 0.75rem);
   display: flex;
   flex-direction: column;
-  gap: clamp(0.5rem, 0.9vw, 0.75rem);
+  gap: clamp(0.3rem, 0.6vw, 0.45rem);
   height: 100%;
   width: 100%;
 }
@@ -2293,11 +2293,11 @@ body.theme-neon .element-bonus-card {
 
 .element-bonus-card:not(.shop-bonus-card) {
   display: grid;
-  grid-template-columns: minmax(220px, 0.75fr) minmax(0, 1fr);
+  grid-template-columns: minmax(140px, 0.6fr) minmax(0, 1fr);
   align-items: center;
-  gap: clamp(0.6rem, 1vw, 0.9rem);
-  min-height: clamp(96px, 8.5vw, 150px);
-  aspect-ratio: 6 / 1;
+  gap: clamp(0.35rem, 0.7vw, 0.5rem);
+  min-height: clamp(56px, 5vw, 90px);
+  aspect-ratio: 8 / 1;
 }
 
 .element-bonus-card:not(.shop-bonus-card) .element-bonus-card__meta,
@@ -2305,7 +2305,7 @@ body.theme-neon .element-bonus-card {
   min-width: 0;
   display: grid;
   align-content: start;
-  gap: clamp(0.55rem, 0.9vw, 0.75rem);
+  gap: clamp(0.3rem, 0.6vw, 0.45rem);
 }
 
 .element-bonus-card:not(.shop-bonus-card) .element-bonus-card__meta {
@@ -2314,7 +2314,7 @@ body.theme-neon .element-bonus-card {
 
 @media (max-width: 1200px) {
   .element-bonus-card:not(.shop-bonus-card) {
-    grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1fr);
+    grid-template-columns: minmax(160px, 0.75fr) minmax(0, 1fr);
   }
 }
 
@@ -2329,26 +2329,26 @@ body.theme-neon .element-bonus-card {
 .element-bonus-card__meta {
   display: flex;
   flex-direction: column;
-  gap: clamp(0.35rem, 0.7vw, 0.6rem);
+  gap: clamp(0.2rem, 0.5vw, 0.35rem);
 }
 
 .element-bonus-counts {
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: clamp(0.3rem, 0.6vw, 0.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: clamp(0.2rem, 0.4vw, 0.35rem);
 }
 
 .element-bonus-count {
   display: grid;
   grid-template-rows: auto auto;
-  gap: 0.2rem;
+  gap: 0.12rem;
   align-content: start;
 }
 
 .element-bonus-count__label {
-  font-size: 0.72rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   opacity: 0.7;
@@ -2357,7 +2357,7 @@ body.theme-neon .element-bonus-card {
 
 .element-bonus-count__value {
   font-family: 'Orbitron', sans-serif;
-  font-size: 1.1rem;
+  font-size: 0.85rem;
   min-width: 0;
   word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- supprime les statuts textuels et simplifie les compteurs des cartes de rareté
- masque la section "Effets spéciaux" pour la rareté Mythe quantique
- réduit l'encombrement visuel des cartes d'information en ajustant leur mise en page

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d59e3fa18c832ea20bbb5d9edb30da