### PR TITLE
Ajuste les libellés APS/APC

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -2249,9 +2249,9 @@ function defineProductionStep(id, type, label, extra = {}) {
 }
 
 defineProductionStep('baseFlat', 'base', 'Base flat', { source: 'baseFlat' });
-defineProductionStep('shopFlat', 'flat', 'Bonus flat magasin', { source: 'shopFlat' });
-defineProductionStep('elementFlat', 'flat', 'Bonus flat éléments', { source: 'elementFlat' });
-defineProductionStep('fusionFlat', 'flat', 'Bonus flat fusions', { source: 'fusionFlat' });
+defineProductionStep('shopFlat', 'flat', 'Magasin', { source: 'shopFlat' });
+defineProductionStep('elementFlat', 'flat', 'Éléments', { source: 'elementFlat' });
+defineProductionStep('fusionFlat', 'flat', 'Fusions', { source: 'fusionFlat' });
 defineProductionStep('shopBonus1', 'multiplier', 'Bonus shop 1', { source: 'shopBonus1' });
 defineProductionStep('shopBonus2', 'multiplier', 'Bonus shop 2', { source: 'shopBonus2' });
 defineProductionStep('frenzy', 'multiplier', 'Frénésie', { source: 'frenzy' });
@@ -2268,7 +2268,7 @@ RARITY_IDS.forEach(rarityId => {
   defineProductionStep(
     `rarityMultiplier:${rarityId}`,
     'multiplier',
-    `Multiplicateur éléments ${rarityLabel}`,
+    `Éléments ${rarityLabel}`,
     { source: 'rarityMultiplier', rarityId }
   );
 });


### PR DESCRIPTION
## Summary
- renomme les libellés de bonus plats pour ne plus afficher "Bonus flat"
- renomme les libellés de multiplicateurs d’éléments pour retirer "Multiplicateur éléments"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bb7b1084832e8fc1c09e8b498b80