### PR TITLE
Add arcade portal unlock and page shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,15 @@
 <body class="theme-dark">
   <header class="app-header">
     <div class="header-main">
-      <div class="brand">Atom2Univers</div>
+      <button
+        class="brand brand-button brand--locked"
+        id="brandPortal"
+        type="button"
+        disabled
+        aria-disabled="true"
+      >
+        Atom2Univers
+      </button>
       <nav class="nav-menu" aria-label="Navigation principale">
         <button class="nav-button active" data-target="game">Atoms</button>
         <button class="nav-button" data-target="shop">Shop</button>
@@ -117,6 +125,18 @@
         <div class="gacha-result" id="gachaResult" role="status" aria-live="assertive"></div>
         <p class="gacha-continue-hint" id="gachaContinueHint">Cliquer pour continuer</p>
       </div>
+    </section>
+
+    <section id="arcade" class="page page--arcade" aria-label="Portail arcade" hidden>
+      <header class="arcade-header" aria-label="Navigation du mode arcade">
+        <button class="arcade-header__title brand brand-button" id="arcadeReturnButton" type="button">
+          Atom2Univers
+        </button>
+        <div class="arcade-header__status" aria-live="polite">
+          <span class="arcade-header__status-label">Tickets</span>
+          <span class="arcade-header__status-value" id="arcadeTicketValue">0 ticket</span>
+        </div>
+      </header>
     </section>
 
     <section id="tableau" class="page page--table" aria-label="Tableau périodique des éléments">

--- a/styles/main.css
+++ b/styles/main.css
@@ -80,6 +80,87 @@ body.theme-neon .app-header {
   font-size: clamp(0.83rem, 1.35vw, 1.2rem);
   letter-spacing: 0.14em;
   text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  white-space: nowrap;
+}
+
+.brand-button {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: default;
+  transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.brand-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 4px;
+}
+
+body.theme-light .brand-button:focus-visible {
+  outline-color: rgba(40, 48, 96, 0.65);
+}
+
+.brand--locked {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.brand--portal-ready {
+  --brand-portal-color: #f9e09c;
+  --brand-portal-glow: rgba(255, 224, 154, 0.55);
+  color: var(--brand-portal-color);
+  cursor: pointer;
+  text-shadow: 0 0.45rem 1.4rem var(--brand-portal-glow);
+}
+
+.brand--portal-ready:hover,
+.brand--portal-ready:focus-visible {
+  transform: translateY(-1px);
+}
+
+body.theme-light .brand--portal-ready {
+  --brand-portal-color: #3a2f7e;
+  --brand-portal-glow: rgba(58, 47, 126, 0.32);
+}
+
+body.theme-neon .brand--portal-ready {
+  --brand-portal-color: #9ff2ff;
+  --brand-portal-glow: rgba(140, 240, 255, 0.65);
+}
+
+.brand--pulse {
+  animation: brandPortalPulse 1.4s ease-in-out forwards;
+}
+
+@keyframes brandPortalPulse {
+  0% {
+    text-shadow: 0 0 0 rgba(255, 255, 255, 0);
+    transform: scale(1);
+  }
+  35% {
+    text-shadow: 0 0.75rem 1.9rem var(--brand-portal-glow, rgba(255, 224, 154, 0.55));
+    transform: scale(1.05);
+  }
+  70% {
+    text-shadow: 0 0.5rem 1.5rem rgba(255, 255, 255, 0.28);
+    transform: scale(1.02);
+  }
+  100% {
+    text-shadow: 0 0.45rem 1.4rem var(--brand-portal-glow, rgba(255, 224, 154, 0.55));
+    transform: scale(1);
+  }
 }
 
 .status-bar {
@@ -391,6 +472,65 @@ main {
 
 .page.active {
   display: block;
+}
+
+.page--arcade {
+  display: none;
+}
+
+.page--arcade.active {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.6rem, 3.6vw, 2.4rem);
+  align-items: stretch;
+}
+
+.arcade-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1rem, 2.6vw, 1.8rem);
+  padding: clamp(1.1rem, 2.8vw, 1.7rem) clamp(1.4rem, 3.4vw, 2.4rem);
+  border-radius: 1.6rem;
+  background: linear-gradient(140deg, rgba(18, 24, 56, 0.78), rgba(8, 12, 34, 0.82));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 46px rgba(6, 10, 32, 0.45);
+}
+
+body.theme-light .arcade-header {
+  background: linear-gradient(140deg, rgba(248, 250, 255, 0.92), rgba(210, 220, 255, 0.9));
+  border-color: rgba(40, 52, 120, 0.18);
+  box-shadow: 0 20px 40px rgba(28, 38, 74, 0.16);
+}
+
+body.theme-neon .arcade-header {
+  background: linear-gradient(140deg, rgba(32, 28, 112, 0.88), rgba(10, 22, 88, 0.9));
+  border-color: rgba(120, 150, 255, 0.28);
+  box-shadow: 0 24px 48px rgba(14, 18, 72, 0.55);
+}
+
+.arcade-header__title {
+  font-size: clamp(0.9rem, 1.6vw, 1.32rem);
+}
+
+.arcade-header__status {
+  display: flex;
+  align-items: baseline;
+  gap: clamp(0.4rem, 1vw, 0.8rem);
+  font-family: 'Orbitron', 'Inter', sans-serif;
+}
+
+.arcade-header__status-label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: clamp(0.62rem, 0.95vw, 0.78rem);
+  opacity: 0.72;
+}
+
+.arcade-header__status-value {
+  font-size: clamp(0.9rem, 1.5vw, 1.18rem);
+  font-weight: 600;
+  letter-spacing: 0.05em;
 }
 
 .page--bigbang {


### PR DESCRIPTION
## Summary
- make the Atom2Univers title a button that unlocks after the million-atoms trophy and opens a new arcade page
- add an empty arcade page with its own header showing the shared gacha ticket count and a return control
- style the title states, unlock pulse effect, and the arcade header layout for all themes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5e74db6cc832e8bd9ef3d0c515fe4