### PR TITLE
Add Particules arcade mini-game with custom layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,16 +127,56 @@
       </div>
     </section>
 
-    <section id="arcade" class="page page--arcade" aria-label="Portail arcade" hidden>
-      <header class="arcade-header" aria-label="Navigation du mode arcade">
-        <button class="arcade-header__title brand brand-button" id="arcadeReturnButton" type="button">
+    <section id="arcade" class="page page--arcade" aria-label="Particules" hidden>
+      <header class="arcade-header" aria-label="Navigation du jeu Particules">
+        <button class="arcade-header__brand brand brand-button" id="arcadeReturnButton" type="button">
           Atom2Univers
         </button>
+        <div class="arcade-header__title" aria-live="polite">
+          <h2 class="arcade-header__game-title">Particules</h2>
+          <p class="arcade-header__subtitle">
+            Canalisez les particules quantiques pour gagner des tickets de tirage.
+          </p>
+        </div>
         <div class="arcade-header__status" aria-live="polite">
           <span class="arcade-header__status-label">Tickets</span>
           <span class="arcade-header__status-value" id="arcadeTicketValue">0 ticket</span>
         </div>
       </header>
+
+      <div class="arcade-content">
+        <div class="arcade-hud" role="status" aria-live="polite">
+          <div class="arcade-hud__item">
+            <span class="arcade-hud__label">Niveau</span>
+            <span class="arcade-hud__value" id="arcadeLevelValue">1</span>
+          </div>
+          <div class="arcade-hud__item">
+            <span class="arcade-hud__label">Vies</span>
+            <span class="arcade-hud__value" id="arcadeLivesValue">3</span>
+          </div>
+          <div class="arcade-hud__item">
+            <span class="arcade-hud__label">Score</span>
+            <span class="arcade-hud__value" id="arcadeScoreValue">0</span>
+          </div>
+        </div>
+
+        <div class="arcade-stage">
+          <canvas
+            id="arcadeGameCanvas"
+            class="arcade-stage__canvas"
+            aria-label="Zone de jeu Particules"
+            role="presentation"
+          ></canvas>
+          <div class="arcade-overlay" id="arcadeOverlay" role="dialog" aria-modal="false" hidden>
+            <div class="arcade-overlay__content">
+              <p class="arcade-overlay__message" id="arcadeOverlayMessage">
+                Touchez ou cliquez la raquette pour guider la particule et détruire les briques quantiques.
+              </p>
+              <button type="button" class="arcade-overlay__button" id="arcadeOverlayButton">Commencer</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section id="tableau" class="page page--table" aria-label="Tableau périodique des éléments">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -4549,6 +4549,13 @@ const elements = {
   gachaContinueHint: document.getElementById('gachaContinueHint'),
   arcadeReturnButton: document.getElementById('arcadeReturnButton'),
   arcadeTicketValue: document.getElementById('arcadeTicketValue'),
+  arcadeCanvas: document.getElementById('arcadeGameCanvas'),
+  arcadeOverlay: document.getElementById('arcadeOverlay'),
+  arcadeOverlayMessage: document.getElementById('arcadeOverlayMessage'),
+  arcadeOverlayButton: document.getElementById('arcadeOverlayButton'),
+  arcadeLevelValue: document.getElementById('arcadeLevelValue'),
+  arcadeLivesValue: document.getElementById('arcadeLivesValue'),
+  arcadeScoreValue: document.getElementById('arcadeScoreValue'),
   themeSelect: document.getElementById('themeSelect'),
   musicTrackSelect: document.getElementById('musicTrackSelect'),
   musicTrackStatus: document.getElementById('musicTrackStatus'),
@@ -6976,6 +6983,669 @@ function updateGachaUI() {
       elements.gachaSunButton.disabled = false;
     }
   }
+}
+
+const ARCADE_TICKET_REWARD = 1;
+
+class ParticulesGame {
+  constructor(options = {}) {
+    const {
+      canvas,
+      overlay,
+      overlayButton,
+      overlayMessage,
+      levelLabel,
+      livesLabel,
+      scoreLabel,
+      onTicketsEarned
+    } = options;
+
+    this.canvas = canvas;
+    this.overlay = overlay;
+    this.overlayButton = overlayButton;
+    this.overlayMessage = overlayMessage;
+    this.levelLabel = levelLabel;
+    this.livesLabel = livesLabel;
+    this.scoreLabel = scoreLabel;
+    this.onTicketsEarned = typeof onTicketsEarned === 'function' ? onTicketsEarned : null;
+
+    if (!this.canvas || !this.canvas.getContext) {
+      this.enabled = false;
+      return;
+    }
+
+    const context = this.canvas.getContext('2d');
+    if (!context) {
+      this.enabled = false;
+      return;
+    }
+
+    this.enabled = true;
+    this.ctx = context;
+    this.level = 1;
+    this.lives = 3;
+    this.score = 0;
+    this.ticketsEarned = 0;
+    this.overlayAction = 'start';
+    this.pointerActive = false;
+    this.pendingResume = false;
+    this.running = false;
+    this.lastTimestamp = 0;
+    this.animationFrameId = null;
+    this.width = 0;
+    this.height = 0;
+
+    this.paddle = {
+      widthRatio: 0.18,
+      minWidthRatio: 0.1,
+      heightRatio: 0.025,
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      xRatio: 0.5
+    };
+
+    this.ball = {
+      radiusRatio: 0.015,
+      baseSpeedRatio: 0.78,
+      speedGrowthRatio: 0.08,
+      x: 0,
+      y: 0,
+      vx: 0,
+      vy: 0,
+      radius: 0,
+      stickToPaddle: true,
+      inPlay: false
+    };
+
+    this.bricks = [];
+
+    this.handleFrame = this.handleFrame.bind(this);
+    this.handlePointerDown = this.handlePointerDown.bind(this);
+    this.handlePointerMove = this.handlePointerMove.bind(this);
+    this.handlePointerUp = this.handlePointerUp.bind(this);
+    this.handleOverlayButtonClick = this.handleOverlayButtonClick.bind(this);
+    this.handleResize = this.handleResize.bind(this);
+
+    this.canvas.addEventListener('pointerdown', this.handlePointerDown);
+    this.canvas.addEventListener('pointermove', this.handlePointerMove);
+    this.canvas.addEventListener('pointerup', this.handlePointerUp);
+    this.canvas.addEventListener('pointerleave', this.handlePointerUp);
+    this.canvas.addEventListener('pointercancel', this.handlePointerUp);
+
+    if (this.overlayButton) {
+      this.overlayButton.addEventListener('click', this.handleOverlayButtonClick);
+    }
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', this.handleResize);
+    }
+
+    this.handleResize();
+    this.setupLevel();
+    this.showOverlay({
+      message:
+        (this.overlayMessage?.textContent || '').trim()
+        || 'Touchez ou cliquez la raquette pour guider la particule et détruire les briques quantiques.',
+      buttonLabel: 'Commencer',
+      action: 'start'
+    });
+  }
+
+  handleResize() {
+    if (!this.enabled) return;
+    const rect = this.canvas.getBoundingClientRect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    const targetWidth = Math.round(width * dpr);
+    const targetHeight = Math.round(height * dpr);
+    if (this.canvas.width !== targetWidth || this.canvas.height !== targetHeight) {
+      this.canvas.width = targetWidth;
+      this.canvas.height = targetHeight;
+      this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    this.width = width;
+    this.height = height;
+    this.updatePaddleMetrics();
+    this.updateBallMetrics();
+    this.render();
+  }
+
+  updatePaddleMetrics() {
+    const widthRatio = Math.max(this.paddle.minWidthRatio, this.paddle.widthRatio);
+    this.paddle.width = this.width * widthRatio;
+    this.paddle.height = this.height * this.paddle.heightRatio;
+    const centerRatio = Number.isFinite(this.paddle.xRatio) ? this.paddle.xRatio : 0.5;
+    const centerX = centerRatio * this.width;
+    const minX = 0;
+    const maxX = Math.max(0, this.width - this.paddle.width);
+    this.paddle.x = Math.min(Math.max(centerX - this.paddle.width / 2, minX), maxX);
+    this.paddle.y = this.height - this.paddle.height * 3;
+    this.paddle.xRatio = (this.paddle.x + this.paddle.width / 2) / this.width;
+  }
+
+  updateBallMetrics() {
+    this.ball.radius = Math.max(6, this.width * this.ball.radiusRatio);
+    if (this.ball.stickToPaddle) {
+      this.updateBallFollowingPaddle();
+    }
+    if (!this.ball.inPlay) {
+      this.render();
+    }
+  }
+
+  getBallSpeed() {
+    const base = Math.max(this.width, this.height);
+    const speed = base * (this.ball.baseSpeedRatio + (this.level - 1) * this.ball.speedGrowthRatio);
+    return Math.min(Math.max(speed, 220), 1400);
+  }
+
+  setupLevel() {
+    if (!this.enabled) return;
+    this.bricks = this.createBricks();
+    this.paddle.widthRatio = Math.max(this.paddle.minWidthRatio, 0.18 - (this.level - 1) * 0.012);
+    this.updatePaddleMetrics();
+    this.prepareServe();
+    this.updateHud();
+    this.render();
+  }
+
+  createBricks() {
+    const columns = Math.min(10, 5 + Math.floor((this.level + 1) / 2));
+    const rows = Math.min(6, 2 + Math.floor((this.level + 2) / 3));
+    const horizontalPadding = 0.08;
+    const verticalPadding = 0.1;
+    const gapX = 0.012;
+    const gapY = 0.015;
+    const availableWidth = Math.max(0.2, 1 - horizontalPadding * 2 - (columns - 1) * gapX);
+    const availableHeight = Math.max(0.2, 0.48 - verticalPadding - (rows - 1) * gapY);
+    const brickWidth = availableWidth / columns;
+    const brickHeight = availableHeight / rows;
+    const bricks = [];
+    for (let row = 0; row < rows; row += 1) {
+      for (let col = 0; col < columns; col += 1) {
+        const relX = horizontalPadding + col * (brickWidth + gapX);
+        const relY = verticalPadding + row * (brickHeight + gapY);
+        bricks.push({
+          relX,
+          relY,
+          relWidth: brickWidth,
+          relHeight: brickHeight,
+          hue: 195 + row * 12 + col * 2,
+          active: true
+        });
+      }
+    }
+    return bricks;
+  }
+
+  prepareServe() {
+    this.ball.inPlay = false;
+    this.ball.stickToPaddle = true;
+    this.ball.vx = 0;
+    this.ball.vy = 0;
+    this.updateBallFollowingPaddle();
+    this.stopAnimation();
+    this.render();
+  }
+
+  updateBallFollowingPaddle() {
+    const offset = Math.max(this.height * 0.015, 6);
+    this.ball.x = this.paddle.x + this.paddle.width / 2;
+    this.ball.y = this.paddle.y - offset;
+  }
+
+  launchBall() {
+    this.ball.stickToPaddle = false;
+    this.ball.inPlay = true;
+    const speed = this.getBallSpeed();
+    const minAngle = -Math.PI / 4;
+    const maxAngle = Math.PI / 4;
+    const angle = minAngle + Math.random() * (maxAngle - minAngle);
+    this.ball.vx = speed * Math.sin(angle);
+    this.ball.vy = -Math.abs(speed * Math.cos(angle));
+    this.startAnimation();
+  }
+
+  startAnimation() {
+    if (this.running) return;
+    this.running = true;
+    this.lastTimestamp = 0;
+    this.animationFrameId = requestAnimationFrame(this.handleFrame);
+  }
+
+  stopAnimation() {
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+    this.running = false;
+    this.lastTimestamp = 0;
+  }
+
+  handleFrame(timestamp) {
+    if (!this.running) return;
+    if (!this.lastTimestamp) {
+      this.lastTimestamp = timestamp;
+    }
+    const delta = Math.min((timestamp - this.lastTimestamp) / 1000, 0.035);
+    this.lastTimestamp = timestamp;
+    this.update(delta);
+    this.render();
+    this.animationFrameId = requestAnimationFrame(this.handleFrame);
+  }
+
+  update(delta) {
+    if (!this.ball.inPlay) {
+      if (this.ball.stickToPaddle) {
+        this.updateBallFollowingPaddle();
+      }
+      return;
+    }
+    this.ball.x += this.ball.vx * delta;
+    this.ball.y += this.ball.vy * delta;
+    this.handleWallCollisions();
+    this.handlePaddleCollision();
+    this.handleBrickCollisions();
+  }
+
+  handleWallCollisions() {
+    if (this.ball.x - this.ball.radius <= 0) {
+      this.ball.x = this.ball.radius;
+      this.ball.vx = Math.abs(this.ball.vx);
+    } else if (this.ball.x + this.ball.radius >= this.width) {
+      this.ball.x = this.width - this.ball.radius;
+      this.ball.vx = -Math.abs(this.ball.vx);
+    }
+    if (this.ball.y - this.ball.radius <= 0) {
+      this.ball.y = this.ball.radius;
+      this.ball.vy = Math.abs(this.ball.vy);
+    }
+    if (this.ball.y - this.ball.radius > this.height) {
+      this.handleLifeLost();
+    }
+  }
+
+  handlePaddleCollision() {
+    if (
+      !this.ball.inPlay
+      || this.ball.vy <= 0
+      || this.ball.y + this.ball.radius < this.paddle.y
+      || this.ball.y - this.ball.radius > this.paddle.y + this.paddle.height
+      || this.ball.x + this.ball.radius < this.paddle.x
+      || this.ball.x - this.ball.radius > this.paddle.x + this.paddle.width
+    ) {
+      return;
+    }
+    const relative = (this.ball.x - (this.paddle.x + this.paddle.width / 2)) / (this.paddle.width / 2);
+    const clamped = Math.max(-1, Math.min(1, relative));
+    const angle = clamped * (Math.PI / 3);
+    const speed = this.getBallSpeed();
+    this.ball.vx = speed * Math.sin(angle);
+    this.ball.vy = -Math.abs(speed * Math.cos(angle));
+    this.ball.y = this.paddle.y - this.ball.radius - 1;
+  }
+
+  handleBrickCollisions() {
+    if (!this.ball.inPlay) return;
+    for (const brick of this.bricks) {
+      if (!brick.active) continue;
+      const x = brick.relX * this.width;
+      const y = brick.relY * this.height;
+      const w = brick.relWidth * this.width;
+      const h = brick.relHeight * this.height;
+      if (
+        this.ball.x + this.ball.radius < x
+        || this.ball.x - this.ball.radius > x + w
+        || this.ball.y + this.ball.radius < y
+        || this.ball.y - this.ball.radius > y + h
+      ) {
+        continue;
+      }
+      const overlapLeft = this.ball.x + this.ball.radius - x;
+      const overlapRight = x + w - (this.ball.x - this.ball.radius);
+      const overlapTop = this.ball.y + this.ball.radius - y;
+      const overlapBottom = y + h - (this.ball.y - this.ball.radius);
+      const minOverlap = Math.min(overlapLeft, overlapRight, overlapTop, overlapBottom);
+      if (minOverlap === overlapLeft) {
+        this.ball.x = x - this.ball.radius;
+        this.ball.vx = -Math.abs(this.ball.vx);
+      } else if (minOverlap === overlapRight) {
+        this.ball.x = x + w + this.ball.radius;
+        this.ball.vx = Math.abs(this.ball.vx);
+      } else if (minOverlap === overlapTop) {
+        this.ball.y = y - this.ball.radius;
+        this.ball.vy = -Math.abs(this.ball.vy);
+      } else {
+        this.ball.y = y + h + this.ball.radius;
+        this.ball.vy = Math.abs(this.ball.vy);
+      }
+      brick.active = false;
+      this.score += 100;
+      this.updateHud();
+      const hasRemaining = this.bricks.some(entry => entry.active);
+      if (!hasRemaining) {
+        this.handleLevelCleared();
+      }
+      break;
+    }
+  }
+
+  handleLevelCleared() {
+    this.ball.inPlay = false;
+    this.stopAnimation();
+    const completedLevel = this.level;
+    const reward = ARCADE_TICKET_REWARD;
+    this.ticketsEarned += reward;
+    if (this.onTicketsEarned) {
+      this.onTicketsEarned(reward, { level: completedLevel, score: this.score });
+    }
+    this.level += 1;
+    this.setupLevel();
+    const rewardLabel = reward === 1 ? '+1 ticket' : `+${formatTicketLabel(reward)}`;
+    this.showOverlay({
+      message: `Niveau ${completedLevel} terminé ! ${rewardLabel}.`,
+      buttonLabel: 'Continuer',
+      action: 'next'
+    });
+  }
+
+  handleLifeLost() {
+    if (!this.ball.inPlay) {
+      return;
+    }
+    this.ball.inPlay = false;
+    this.stopAnimation();
+    this.lives = Math.max(0, this.lives - 1);
+    this.updateHud();
+    if (this.lives > 0) {
+      this.prepareServe();
+      this.showOverlay({
+        message: 'Particule perdue ! Touchez la raquette pour continuer.',
+        buttonLabel: 'Reprendre',
+        action: 'resume'
+      });
+    } else {
+      this.gameOver();
+    }
+  }
+
+  gameOver() {
+    this.ball.inPlay = false;
+    this.stopAnimation();
+    this.prepareServe();
+    const ticketSummary = formatTicketLabel(this.ticketsEarned);
+    const message = this.ticketsEarned > 0
+      ? `Partie terminée ! Tickets gagnés : ${ticketSummary}.`
+      : 'Partie terminée ! Aucun ticket gagné cette fois-ci.';
+    this.showOverlay({
+      message,
+      buttonLabel: 'Rejouer',
+      action: 'restart'
+    });
+  }
+
+  updateHud() {
+    if (this.levelLabel) {
+      this.levelLabel.textContent = `${this.level}`;
+    }
+    if (this.livesLabel) {
+      this.livesLabel.textContent = `${this.lives}`;
+    }
+    if (this.scoreLabel) {
+      this.scoreLabel.textContent = `${this.score}`;
+    }
+  }
+
+  isOverlayVisible() {
+    return !!this.overlay && !this.overlay.hasAttribute('hidden');
+  }
+
+  showOverlay({ message, buttonLabel, action } = {}) {
+    if (!this.overlay) return;
+    if (typeof message === 'string' && this.overlayMessage) {
+      this.overlayMessage.textContent = message;
+    }
+    if (typeof buttonLabel === 'string' && this.overlayButton) {
+      this.overlayButton.textContent = buttonLabel;
+    }
+    this.overlay.removeAttribute('hidden');
+    this.overlayAction = action || null;
+  }
+
+  hideOverlay() {
+    if (!this.overlay) return;
+    if (!this.overlay.hasAttribute('hidden')) {
+      this.overlay.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  handleOverlayButtonClick() {
+    switch (this.overlayAction) {
+      case 'start':
+      case 'restart':
+        this.startNewGame();
+        break;
+      case 'resume':
+        this.resumeFromPause();
+        break;
+      case 'next':
+        this.startNextLevel();
+        break;
+      default:
+        this.hideOverlay();
+        break;
+    }
+  }
+
+  startNewGame() {
+    this.level = 1;
+    this.lives = 3;
+    this.score = 0;
+    this.ticketsEarned = 0;
+    this.pendingResume = false;
+    this.setupLevel();
+    this.hideOverlay();
+    this.launchBall();
+  }
+
+  resumeFromPause() {
+    this.pendingResume = false;
+    this.hideOverlay();
+    this.launchBall();
+  }
+
+  startNextLevel() {
+    this.hideOverlay();
+    this.setupLevel();
+    this.launchBall();
+  }
+
+  handlePointerDown(event) {
+    if (!this.enabled || this.isOverlayVisible()) return;
+    this.pointerActive = true;
+    if (this.canvas.setPointerCapture) {
+      try {
+        this.canvas.setPointerCapture(event.pointerId);
+      } catch (error) {
+        // ignore pointer capture errors
+      }
+    }
+    this.updatePaddleFromPointer(event);
+    event.preventDefault();
+  }
+
+  handlePointerMove(event) {
+    if (!this.enabled || !this.pointerActive) return;
+    this.updatePaddleFromPointer(event);
+    event.preventDefault();
+  }
+
+  handlePointerUp(event) {
+    if (!this.enabled) return;
+    if (this.canvas.releasePointerCapture) {
+      try {
+        this.canvas.releasePointerCapture(event.pointerId);
+      } catch (error) {
+        // ignore pointer capture errors
+      }
+    }
+    this.pointerActive = false;
+  }
+
+  updatePaddleFromPointer(event) {
+    const rect = this.canvas.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const ratio = (event.clientX - rect.left) / rect.width;
+    const clampedRatio = Math.min(Math.max(ratio, 0), 1);
+    const center = clampedRatio * this.width;
+    const minX = 0;
+    const maxX = Math.max(0, this.width - this.paddle.width);
+    this.paddle.x = Math.min(Math.max(center - this.paddle.width / 2, minX), maxX);
+    this.paddle.xRatio = (this.paddle.x + this.paddle.width / 2) / this.width;
+    if (this.ball.stickToPaddle) {
+      this.updateBallFollowingPaddle();
+    }
+  }
+
+  onEnter() {
+    if (!this.enabled) return;
+    this.handleResize();
+    if (this.pendingResume && !this.isOverlayVisible()) {
+      this.showOverlay({
+        message: 'Partie en pause. Touchez la raquette pour continuer.',
+        buttonLabel: 'Reprendre',
+        action: 'resume'
+      });
+      this.pendingResume = false;
+    }
+    if (this.ball.inPlay && !this.isOverlayVisible()) {
+      this.startAnimation();
+    } else {
+      this.render();
+    }
+  }
+
+  onLeave() {
+    if (!this.enabled) return;
+    if (this.ball.inPlay && !this.isOverlayVisible()) {
+      this.pendingResume = true;
+      this.prepareServe();
+    }
+    this.stopAnimation();
+  }
+
+  render() {
+    if (!this.enabled) return;
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.width, this.height);
+    const background = ctx.createLinearGradient(0, 0, this.width, this.height);
+    background.addColorStop(0, 'rgba(18, 24, 56, 0.6)');
+    background.addColorStop(1, 'rgba(6, 10, 28, 0.92)');
+    ctx.fillStyle = background;
+    ctx.fillRect(0, 0, this.width, this.height);
+
+    const hasRoundRect = typeof ctx.roundRect === 'function';
+    this.bricks.forEach(brick => {
+      if (!brick.active) return;
+      const x = brick.relX * this.width;
+      const y = brick.relY * this.height;
+      const w = brick.relWidth * this.width;
+      const h = brick.relHeight * this.height;
+      const gradient = ctx.createLinearGradient(x, y, x, y + h);
+      gradient.addColorStop(0, `hsla(${brick.hue}, 75%, 62%, 0.95)`);
+      gradient.addColorStop(1, `hsla(${brick.hue + 12}, 65%, 48%, 0.9)`);
+      ctx.fillStyle = gradient;
+      const radius = Math.min(12, h * 0.4);
+      if (hasRoundRect) {
+        ctx.beginPath();
+        ctx.roundRect(x, y, w, h, radius);
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+        ctx.lineWidth = Math.max(1, h * 0.06);
+        ctx.stroke();
+      } else {
+        ctx.fillRect(x, y, w, h);
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+        ctx.lineWidth = Math.max(1, h * 0.06);
+        ctx.strokeRect(x, y, w, h);
+      }
+    });
+
+    const paddleGradient = ctx.createLinearGradient(
+      this.paddle.x,
+      this.paddle.y,
+      this.paddle.x,
+      this.paddle.y + this.paddle.height
+    );
+    paddleGradient.addColorStop(0, 'rgba(120, 220, 255, 0.95)');
+    paddleGradient.addColorStop(1, 'rgba(86, 140, 255, 0.85)');
+    ctx.fillStyle = paddleGradient;
+    const paddleRadius = Math.min(18, this.paddle.height * 1.2);
+    if (hasRoundRect) {
+      ctx.beginPath();
+      ctx.roundRect(this.paddle.x, this.paddle.y, this.paddle.width, this.paddle.height, paddleRadius);
+      ctx.fill();
+    } else {
+      ctx.fillRect(this.paddle.x, this.paddle.y, this.paddle.width, this.paddle.height);
+    }
+
+    const ballGradient = ctx.createRadialGradient(
+      this.ball.x - this.ball.radius / 3,
+      this.ball.y - this.ball.radius / 3,
+      this.ball.radius * 0.2,
+      this.ball.x,
+      this.ball.y,
+      this.ball.radius
+    );
+    ballGradient.addColorStop(0, 'rgba(255, 255, 255, 0.95)');
+    ballGradient.addColorStop(1, 'rgba(120, 200, 255, 0.9)');
+    ctx.fillStyle = ballGradient;
+    ctx.beginPath();
+    ctx.arc(this.ball.x, this.ball.y, this.ball.radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.strokeStyle = 'rgba(150, 220, 255, 0.25)';
+    ctx.lineWidth = Math.max(1, this.ball.radius * 0.25);
+    ctx.beginPath();
+    ctx.arc(this.ball.x, this.ball.y, this.ball.radius * 1.2, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+let particulesGame = null;
+
+function initParticulesGame() {
+  if (particulesGame || !elements.arcadeCanvas) {
+    return;
+  }
+  particulesGame = new ParticulesGame({
+    canvas: elements.arcadeCanvas,
+    overlay: elements.arcadeOverlay,
+    overlayButton: elements.arcadeOverlayButton,
+    overlayMessage: elements.arcadeOverlayMessage,
+    levelLabel: elements.arcadeLevelValue,
+    livesLabel: elements.arcadeLivesValue,
+    scoreLabel: elements.arcadeScoreValue,
+    onTicketsEarned: (count = 0) => {
+      const reward = Math.max(0, Math.floor(Number(count) || 0));
+      if (reward <= 0) {
+        return;
+      }
+      const current = Math.max(0, Math.floor(Number(gameState.gachaTickets) || 0));
+      gameState.gachaTickets = current + reward;
+      updateGachaUI();
+      saveGame();
+      const rewardLabel = formatTicketLabel(reward);
+      showToast(`+${rewardLabel} grâce à Particules !`);
+    }
+  });
+  updateArcadeTicketDisplay();
 }
 
 function performGachaRoll(count = 1) {
@@ -9928,6 +10598,13 @@ function showPage(pageId) {
   document.body.dataset.activePage = pageId;
   document.body.classList.toggle('view-game', pageId === 'game');
   document.body.classList.toggle('view-arcade', pageId === 'arcade');
+  if (particulesGame) {
+    if (pageId === 'arcade') {
+      particulesGame.onEnter();
+    } else {
+      particulesGame.onLeave();
+    }
+  }
   if (pageId === 'game' && (typeof document === 'undefined' || !document.hidden)) {
     gamePageVisibleSince = now;
   } else {
@@ -9948,8 +10625,16 @@ document.addEventListener('visibilitychange', () => {
   }
   if (document.hidden) {
     gamePageVisibleSince = null;
+    if (particulesGame && document.body?.dataset.activePage === 'arcade') {
+      particulesGame.onLeave();
+    }
   } else if (isGamePageActive()) {
     gamePageVisibleSince = performance.now();
+    if (particulesGame && document.body?.dataset.activePage === 'arcade') {
+      particulesGame.onEnter();
+    }
+  } else if (particulesGame && document.body?.dataset.activePage === 'arcade') {
+    particulesGame.onEnter();
   }
 });
 
@@ -10063,6 +10748,8 @@ document.addEventListener('keydown', event => {
 });
 
 updateDevKitUI();
+
+initParticulesGame();
 
 elements.navButtons.forEach(btn => {
   btn.addEventListener('click', () => showPage(btn.dataset.target));

--- a/styles/main.css
+++ b/styles/main.css
@@ -57,6 +57,19 @@ body.theme-neon {
   user-select: none;
 }
 
+body.view-arcade {
+  background: radial-gradient(140% 160% at 50% 0%, #1a1e48 0%, #070918 55%, #01020a 100%);
+}
+
+body.view-arcade .app-header {
+  display: none;
+}
+
+body.view-arcade main {
+  width: 100%;
+  justify-content: center;
+}
+
 body.theme-light .app-header {
   background: rgba(246, 247, 251, 0.78);
   border-bottom-color: rgba(12, 16, 32, 0.08);
@@ -476,6 +489,9 @@ main {
 
 .page--arcade {
   display: none;
+  width: 100%;
+  max-width: min(1200px, 96vw);
+  margin: 0 auto;
 }
 
 .page--arcade.active {
@@ -483,6 +499,7 @@ main {
   flex-direction: column;
   gap: clamp(1.6rem, 3.6vw, 2.4rem);
   align-items: stretch;
+  min-height: clamp(540px, 70vh, 860px);
 }
 
 .arcade-header {
@@ -497,20 +514,44 @@ main {
   box-shadow: 0 24px 46px rgba(6, 10, 32, 0.45);
 }
 
-body.theme-light .arcade-header {
-  background: linear-gradient(140deg, rgba(248, 250, 255, 0.92), rgba(210, 220, 255, 0.9));
-  border-color: rgba(40, 52, 120, 0.18);
-  box-shadow: 0 20px 40px rgba(28, 38, 74, 0.16);
+.arcade-header__brand {
+  flex-shrink: 0;
+  padding-inline: clamp(0.6rem, 1.2vw, 1rem);
+  padding-block: clamp(0.35rem, 0.8vw, 0.6rem);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-body.theme-neon .arcade-header {
-  background: linear-gradient(140deg, rgba(32, 28, 112, 0.88), rgba(10, 22, 88, 0.9));
-  border-color: rgba(120, 150, 255, 0.28);
-  box-shadow: 0 24px 48px rgba(14, 18, 72, 0.55);
+.arcade-header__brand:hover,
+.arcade-header__brand:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(12, 16, 40, 0.35);
 }
 
 .arcade-header__title {
-  font-size: clamp(0.9rem, 1.6vw, 1.32rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.25rem, 0.8vw, 0.5rem);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.arcade-header__game-title {
+  margin: 0;
+  font-family: 'Audiowide', 'Orbitron', sans-serif;
+  font-size: clamp(1.4rem, 3.1vw, 2rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.arcade-header__subtitle {
+  margin: 0;
+  font-size: clamp(0.8rem, 1.4vw, 1.05rem);
+  color: rgba(230, 234, 255, 0.78);
+  max-width: 52ch;
 }
 
 .arcade-header__status {
@@ -518,6 +559,10 @@ body.theme-neon .arcade-header {
   align-items: baseline;
   gap: clamp(0.4rem, 1vw, 0.8rem);
   font-family: 'Orbitron', 'Inter', sans-serif;
+  padding: clamp(0.5rem, 1vw, 0.9rem) clamp(0.8rem, 1.4vw, 1.2rem);
+  border-radius: 1.2rem;
+  background: rgba(16, 22, 48, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .arcade-header__status-label {
@@ -532,6 +577,177 @@ body.theme-neon .arcade-header {
   font-weight: 600;
   letter-spacing: 0.05em;
 }
+
+body.theme-light .arcade-header {
+  background: linear-gradient(140deg, rgba(248, 250, 255, 0.92), rgba(210, 220, 255, 0.9));
+  border-color: rgba(40, 52, 120, 0.18);
+  box-shadow: 0 20px 40px rgba(28, 38, 74, 0.16);
+}
+
+body.theme-light .arcade-header__brand {
+  border-color: rgba(40, 52, 120, 0.18);
+  background: rgba(12, 16, 32, 0.06);
+}
+
+body.theme-light .arcade-header__subtitle {
+  color: rgba(18, 24, 52, 0.72);
+}
+
+body.theme-light .arcade-header__status {
+  background: rgba(240, 244, 255, 0.82);
+  border-color: rgba(48, 64, 120, 0.16);
+}
+
+body.theme-neon .arcade-header {
+  background: linear-gradient(140deg, rgba(32, 28, 112, 0.88), rgba(10, 22, 88, 0.9));
+  border-color: rgba(120, 150, 255, 0.28);
+  box-shadow: 0 24px 48px rgba(14, 18, 72, 0.55);
+}
+
+body.theme-neon .arcade-header__subtitle {
+  color: rgba(190, 200, 255, 0.85);
+}
+
+body.theme-neon .arcade-header__status {
+  background: rgba(38, 32, 110, 0.8);
+  border-color: rgba(160, 190, 255, 0.32);
+}
+
+.arcade-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.2rem, 2.8vw, 1.8rem);
+  flex: 1 1 auto;
+}
+
+.arcade-hud {
+  display: flex;
+  justify-content: center;
+  gap: clamp(1rem, 2.2vw, 2rem);
+  padding: clamp(0.8rem, 2vw, 1.2rem) clamp(1.2rem, 3vw, 2.2rem);
+  border-radius: 1.4rem;
+  background: rgba(12, 18, 40, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  font-family: 'Orbitron', 'Inter', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.arcade-hud__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  align-items: center;
+}
+
+.arcade-hud__label {
+  font-size: clamp(0.58rem, 0.8vw, 0.72rem);
+  opacity: 0.65;
+}
+
+.arcade-hud__value {
+  font-size: clamp(0.98rem, 1.6vw, 1.4rem);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+body.theme-light .arcade-hud {
+  background: rgba(244, 246, 255, 0.9);
+  border-color: rgba(40, 48, 90, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+body.theme-light .arcade-hud__label {
+  color: rgba(30, 40, 78, 0.65);
+}
+
+body.theme-neon .arcade-hud {
+  background: rgba(42, 32, 110, 0.78);
+  border-color: rgba(150, 170, 255, 0.26);
+}
+
+.arcade-stage {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: clamp(420px, 58vh, 620px);
+  border-radius: 1.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: radial-gradient(circle at top, rgba(28, 36, 88, 0.65), rgba(8, 12, 34, 0.95));
+  overflow: hidden;
+  box-shadow: 0 32px 68px rgba(6, 8, 28, 0.55);
+}
+
+.arcade-stage::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(120, 190, 255, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.arcade-stage__canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  position: relative;
+  z-index: 1;
+  touch-action: none;
+  cursor: pointer;
+}
+
+.arcade-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.2rem, 4vw, 2.4rem);
+  background: rgba(4, 6, 18, 0.78);
+  backdrop-filter: blur(10px);
+  z-index: 2;
+}
+
+.arcade-overlay__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.8rem, 2vw, 1.2rem);
+  max-width: min(420px, 86vw);
+  text-align: center;
+}
+
+.arcade-overlay__message {
+  margin: 0;
+  font-size: clamp(0.9rem, 1.6vw, 1.2rem);
+  line-height: 1.5;
+}
+
+.arcade-overlay__button {
+  align-self: center;
+  padding: clamp(0.55rem, 1.2vw, 0.85rem) clamp(1.4rem, 3vw, 2.2rem);
+  border-radius: 999px;
+  border: none;
+  font-family: 'Orbitron', 'Inter', sans-serif;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: clamp(0.68rem, 1vw, 0.82rem);
+  cursor: pointer;
+  color: #02040c;
+  background: linear-gradient(120deg, #6ee7ff, #67d6ff 45%, #cba4ff);
+  box-shadow: 0 14px 28px rgba(80, 210, 255, 0.45);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.arcade-overlay__button:hover,
+.arcade-overlay__button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px rgba(120, 220, 255, 0.55);
+}
+
+.arcade-overlay[hidden] {
+  display: none;
+}
+
 
 .page--bigbang {
   display: none;


### PR DESCRIPTION
## Summary
- add the Particules arcade page markup with its own header, HUD, and canvas overlay
- style the new arcade view and hide the primary header when the arcade is active
- implement the ParticulesGame mini-game that awards tickets and integrate it with navigation/state

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5f15d1978832e85a561cfd13add11