### PR TITLE
Adjust Particules layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,21 +139,6 @@
       </header>
 
       <div class="arcade-content">
-        <div class="arcade-hud" role="status" aria-live="polite">
-          <div class="arcade-hud__item">
-            <span class="arcade-hud__label">Niveau</span>
-            <span class="arcade-hud__value" id="arcadeLevelValue">1</span>
-          </div>
-          <div class="arcade-hud__item">
-            <span class="arcade-hud__label">Vies</span>
-            <span class="arcade-hud__value" id="arcadeLivesValue">3</span>
-          </div>
-          <div class="arcade-hud__item">
-            <span class="arcade-hud__label">Score</span>
-            <span class="arcade-hud__value" id="arcadeScoreValue">0</span>
-          </div>
-        </div>
-
         <div class="arcade-stage">
           <canvas
             id="arcadeGameCanvas"

--- a/styles/main.css
+++ b/styles/main.css
@@ -490,28 +490,38 @@ main {
 .page--arcade {
   display: none;
   width: 100%;
-  max-width: min(1200px, 96vw);
+  max-width: 100%;
   margin: 0 auto;
+  --arcade-padding-x: clamp(0.8rem, 2vw, 1.2rem);
+  --arcade-padding-top: clamp(0rem, 0.6vw, 0.4rem);
+  --arcade-padding-bottom: clamp(1rem, 2.8vw, 1.6rem);
+  --arcade-stage-spacing: clamp(1rem, 3vh, 2.4rem);
+  --arcade-header-height: clamp(2.9rem, 5.5vh, 3.8rem);
+  --arcade-vertical-offset: calc(
+    var(--arcade-padding-top) + var(--arcade-padding-bottom) + var(--arcade-stage-spacing) * 2 + var(--arcade-header-height)
+  );
+  padding: var(--arcade-padding-top) var(--arcade-padding-x) var(--arcade-padding-bottom);
 }
 
 .page--arcade.active {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.6rem, 3.6vw, 2.4rem);
-  align-items: stretch;
-  min-height: clamp(540px, 70vh, 860px);
+  gap: clamp(1rem, 2.6vw, 1.8rem);
+  align-items: center;
+  min-height: 100vh;
 }
 
 .arcade-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: clamp(0.6rem, 1.6vw, 1.2rem);
-  padding: clamp(0.55rem, 1.4vw, 0.85rem) clamp(0.8rem, 2vw, 1.2rem);
-  border-radius: 1.6rem;
+  gap: clamp(0.5rem, 1.4vw, 1rem);
+  min-height: var(--arcade-header-height);
+  padding: clamp(0.4rem, 1.1vw, 0.7rem) clamp(0.7rem, 1.6vw, 1rem);
+  border-radius: 1rem;
   background: linear-gradient(140deg, rgba(18, 24, 56, 0.78), rgba(8, 12, 34, 0.82));
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 36px rgba(6, 10, 32, 0.4);
+  box-shadow: 0 12px 28px rgba(6, 10, 32, 0.32);
 }
 
 .arcade-header__brand {
@@ -637,89 +647,43 @@ body.theme-neon .arcade-header__status {
 
 .arcade-content {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: clamp(1.2rem, 2.8vw, 1.8rem);
-  flex: 1 1 auto;
-}
-
-.arcade-hud {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: stretch;
-  gap: clamp(0.8rem, 1.8vw, 1.4rem);
-  padding: clamp(1rem, 2.4vw, 1.5rem) clamp(1.2rem, 3vw, 2rem);
-  border-radius: 1.4rem;
-  background: rgba(12, 18, 40, 0.68);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-  font-family: 'Orbitron', 'Inter', sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  flex: 0 0 clamp(220px, 26vw, 280px);
-  min-width: clamp(200px, 24vw, 260px);
-}
-
-.arcade-hud__item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
   align-items: center;
-}
-
-.arcade-hud__label {
-  font-size: clamp(0.58rem, 0.8vw, 0.72rem);
-  opacity: 0.65;
-}
-
-.arcade-hud__value {
-  font-size: clamp(0.98rem, 1.6vw, 1.4rem);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-}
-
-body.theme-light .arcade-hud {
-  background: rgba(244, 246, 255, 0.9);
-  border-color: rgba(40, 48, 90, 0.12);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-}
-
-body.theme-light .arcade-hud__label {
-  color: rgba(30, 40, 78, 0.65);
-}
-
-body.theme-neon .arcade-hud {
-  background: rgba(42, 32, 110, 0.78);
-  border-color: rgba(150, 170, 255, 0.26);
+  justify-content: center;
+  flex: 1 1 auto;
+  width: 100%;
+  padding-block: var(--arcade-stage-spacing);
 }
 
 .arcade-stage {
   position: relative;
-  flex: 1 1 520px;
-  min-height: clamp(420px, 58vh, 620px);
-  border-radius: 1.6rem;
+  flex: 0 1 auto;
+  width: min(
+    max(520px, calc((100vh - var(--arcade-vertical-offset)) * 1.6)),
+    calc(100vw - var(--arcade-padding-x) * 2),
+    1400px
+  );
+  max-height: max(0px, calc(100vh - var(--arcade-vertical-offset)));
+  aspect-ratio: 16 / 10;
+  border-radius: 1.4rem;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: radial-gradient(circle at top, rgba(28, 36, 88, 0.65), rgba(8, 12, 34, 0.95));
   overflow: hidden;
   box-shadow: 0 32px 68px rgba(6, 8, 28, 0.55);
 }
 
-@media (max-width: 720px) {
-  .arcade-content {
-    flex-direction: column;
-  }
-
-  .arcade-hud {
-    flex-direction: row;
-    justify-content: center;
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
+@media (max-width: 960px) {
   .arcade-stage {
-    flex: 1 1 auto;
+    width: min(
+      calc(100vw - var(--arcade-padding-x) * 2),
+      max(360px, calc((100vh - var(--arcade-vertical-offset)) * 1.6))
+    );
+  }
+}
+
+@media (max-width: 640px) {
+  .arcade-stage {
+    width: calc(100vw - var(--arcade-padding-x) * 2);
+    max-height: calc((100vw - var(--arcade-padding-x) * 2) / 1.6);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the HUD panel from the Particules arcade page and keep the stage centered
- tighten the arcade header spacing so it sits flush to the top of the viewport
- resize the arcade stage with a 16:10 aspect ratio that expands to fill the available screen space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d60209c5e4832e81b4700efdac8e60