### PR TITLE
Gate navigation pages behind unlock conditions

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
       <nav class="nav-menu" aria-label="Navigation principale">
         <button class="nav-button active" data-target="game">Atoms</button>
         <button class="nav-button" data-target="shop">Shop</button>
-        <button class="nav-button" data-target="gacha">Gacha</button>
-        <button class="nav-button" data-target="tableau">Table</button>
-        <button class="nav-button" data-target="fusion">Fusion</button>
-        <button class="nav-button" data-target="info">Infos</button>
+        <button class="nav-button" data-target="gacha" hidden aria-hidden="true">Gacha</button>
+        <button class="nav-button" data-target="tableau" hidden aria-hidden="true">Table</button>
+        <button class="nav-button" data-target="fusion" hidden aria-hidden="true">Fusion</button>
+        <button class="nav-button" data-target="info" hidden aria-hidden="true">Infos</button>
         <button class="nav-button" data-target="goals">Goals</button>
         <button class="nav-button" data-target="bigbang" id="navBigBangButton" hidden aria-hidden="true">Big Bang</button>
         <button class="nav-button" data-target="options">Options</button>
@@ -414,6 +414,7 @@
           <h3 id="devkitUnlockTitle">Déblocages instantanés</h3>
           <button type="button" class="devkit-action" id="devkitUnlockTrophies">Débloquer tous les succès</button>
           <button type="button" class="devkit-action" id="devkitUnlockElements">Débloquer tout le tableau périodique</button>
+          <button type="button" class="devkit-action" id="devkitUnlockInfo">Débloquer la page Infos</button>
         </section>
         <section class="devkit-section" aria-labelledby="devkitModesTitle">
           <h3 id="devkitModesTitle">Modes persistants</h3>


### PR DESCRIPTION
## Summary
- hide the Gacha, Table, Fusion and Info navigation entries until players meet their new unlock conditions
- couple gacha progression with ticket gains, rolls and trophy state so ticket stars and pages unlock at the correct time even after loading saves
- add a DevKit action for the Info page and improve the arcade ticket button behaviour while the gacha portal is locked

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60a2c14bc832e981dd9557f30bd57