### PR TITLE
Adjust Particules grid layout and HUD

### DIFF
--- a/scripts/particules.js
+++ b/scripts/particules.js
@@ -207,10 +207,19 @@
       this.overlay = overlay;
       this.overlayButton = overlayButton;
       this.overlayMessage = overlayMessage;
-      this.levelLabel = levelLabel;
-      this.livesLabel = livesLabel;
-      this.scoreLabel = scoreLabel;
       this.comboLabel = comboLabel;
+      [levelLabel, livesLabel, scoreLabel].forEach(label => {
+        const container = typeof label?.closest === 'function'
+          ? label.closest('.arcade-hud__item')
+          : null;
+        if (container) {
+          container.hidden = true;
+          container.setAttribute('aria-hidden', 'true');
+        }
+      });
+      this.levelLabel = null;
+      this.livesLabel = null;
+      this.scoreLabel = null;
       this.onTicketsEarned = typeof onTicketsEarned === 'function' ? onTicketsEarned : null;
       this.onSpecialTicket = typeof onSpecialTicket === 'function' ? onSpecialTicket : null;
       this.formatTicketLabel = typeof formatTicketLabel === 'function' ? formatTicketLabel : defaultTicketFormatter;
@@ -274,8 +283,8 @@
 
       this.ballSettings = {
         radiusRatio: 0.015,
-        baseSpeedRatio: 0.8,
-        speedGrowthRatio: 0.08
+        baseSpeedRatio: 1.2,
+        speedGrowthRatio: 0.12
       };
 
       this.handleFrame = this.handleFrame.bind(this);
@@ -387,11 +396,15 @@
     generateBricks() {
       const bricks = [];
       const paddingX = 0.08;
-      const paddingY = 0.08;
+      const paddingY = 0.04;
       const usableWidth = 1 - paddingX * 2;
-      const usableHeight = 0.74;
+      const usableHeight = 0.46;
       const brickWidth = usableWidth / this.gridCols;
       const brickHeight = usableHeight / this.gridRows;
+      const innerWidthRatio = 0.92;
+      const innerHeightRatio = 0.68;
+      const horizontalOffset = (1 - innerWidthRatio) / 2;
+      const verticalOffset = (1 - innerHeightRatio) / 2;
       const baseFill = clamp(0.55 + (this.level - 1) * 0.02, 0.55, 0.82);
       for (let row = 0; row < this.gridRows; row += 1) {
         let rowHasBrick = false;
@@ -400,10 +413,10 @@
           const position = {
             row,
             col,
-            relX: paddingX + col * brickWidth,
-            relY: paddingY + row * brickHeight,
-            relWidth: brickWidth * 0.92,
-            relHeight: brickHeight * 0.88
+            relX: paddingX + col * brickWidth + brickWidth * horizontalOffset,
+            relY: paddingY + row * brickHeight + brickHeight * verticalOffset,
+            relWidth: brickWidth * innerWidthRatio,
+            relHeight: brickHeight * innerHeightRatio
           };
           const variability = (Math.random() - 0.5) * 0.12;
           const depthBias = clamp((row / Math.max(1, this.gridRows - 1)) * 0.18, 0, 0.18);

--- a/styles/main.css
+++ b/styles/main.css
@@ -736,48 +736,20 @@ body.theme-neon .arcade-header__status--info {
 
 .arcade-stage__hud {
   position: absolute;
-  inset: clamp(0.6rem, 1.4vw, 1.1rem) clamp(0.8rem, 1.8vw, 1.4rem) auto;
+  bottom: clamp(0.4rem, 1.6vw, 1.2rem);
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   flex-direction: column;
-  gap: clamp(0.5rem, 1vw, 0.85rem);
+  align-items: center;
+  gap: clamp(0.4rem, 0.9vw, 0.75rem);
   z-index: 2;
   pointer-events: none;
   color: rgba(230, 240, 255, 0.92);
 }
 
-.arcade-hud {
-  display: flex;
-  align-items: center;
-  gap: clamp(0.6rem, 1.2vw, 1rem);
-  margin: 0;
-}
-
-.arcade-hud__item {
-  display: grid;
-  grid-auto-flow: row;
-  justify-items: start;
-  gap: 0.12rem;
-  padding: clamp(0.35rem, 0.8vw, 0.55rem) clamp(0.6rem, 1.2vw, 0.9rem);
-  border-radius: 0.85rem;
-  background: rgba(8, 12, 28, 0.45);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 10px 26px rgba(4, 8, 26, 0.32);
-}
-
-.arcade-hud__label {
-  margin: 0;
-  font-size: clamp(0.58rem, 0.9vw, 0.75rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  opacity: 0.72;
-}
-
-.arcade-hud__value {
-  margin: 0;
-  font-size: clamp(1rem, 1.8vw, 1.35rem);
-  font-family: 'Orbitron', 'Inter', sans-serif;
-  letter-spacing: 0.08em;
-  font-weight: 600;
+.arcade-stage__hud .arcade-hud {
+  display: none;
 }
 
 .arcade-hud__combo {
@@ -785,6 +757,7 @@ body.theme-neon .arcade-header__status--info {
   min-height: 1.2em;
   font-size: clamp(0.72rem, 1.2vw, 0.95rem);
   letter-spacing: 0.08em;
+  text-align: center;
   text-shadow: 0 0 12px rgba(160, 220, 255, 0.45);
 }
 
@@ -792,19 +765,8 @@ body.theme-light .arcade-stage__hud {
   color: rgba(14, 22, 48, 0.92);
 }
 
-body.theme-light .arcade-hud__item {
-  background: rgba(248, 250, 255, 0.78);
-  border-color: rgba(36, 48, 92, 0.14);
-  box-shadow: 0 12px 28px rgba(14, 18, 52, 0.18);
-}
-
 body.theme-light .arcade-hud__combo {
   text-shadow: 0 0 12px rgba(48, 86, 148, 0.32);
-}
-
-body.theme-neon .arcade-hud__item {
-  background: rgba(32, 28, 96, 0.75);
-  border-color: rgba(160, 200, 255, 0.26);
 }
 
 body.theme-neon .arcade-hud__combo {


### PR DESCRIPTION
## Summary
- reposition the Particules brick grid into the upper half of the playfield and reduce brick height for a slimmer layout
- increase the ball's base and growth speed and hide the level, lives, and score HUD entries
- relocate the bonus message display so it appears centered beneath the paddle

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d62b4097f8832ebfe60dce0cc85b9a