### PR TITLE
Add electrified particle visuals and adjust arcade layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -495,9 +495,9 @@ main {
   max-width: 100%;
   margin: 0 auto;
   --arcade-padding-x: clamp(0.8rem, 2vw, 1.2rem);
-  --arcade-padding-top: clamp(0rem, 0.6vw, 0.4rem);
+  --arcade-padding-top: clamp(0rem, 0.2vw, 0.15rem);
   --arcade-padding-bottom: clamp(1rem, 2.8vw, 1.6rem);
-  --arcade-stage-spacing: clamp(1rem, 3vh, 2.4rem);
+  --arcade-stage-spacing: clamp(0.25rem, 1.4vh, 0.8rem);
   --arcade-header-height: clamp(2.9rem, 5.5vh, 3.8rem);
   --arcade-vertical-offset: calc(
     var(--arcade-padding-top) + var(--arcade-padding-bottom) + var(--arcade-stage-spacing) * 2 + var(--arcade-header-height)
@@ -508,7 +508,7 @@ main {
 .page--arcade.active {
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2.6vw, 1.8rem);
+  gap: clamp(0.2rem, 0.9vw, 0.6rem);
   align-items: center;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add animated electric aura and lightning arcs around Particules balls
- render a pulsing blue floor shield when the FLOOR bonus is active and a red energized floor otherwise
- tighten arcade page spacing so the Particules stage sits much closer to the main menu

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64fb708b8832ea5dddf25a9991eca