### PR TITLE
Add legend panel to Particules arcade page

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,43 @@
             </div>
           </div>
         </div>
+        <aside class="arcade-legend" aria-label="Légende des particules élémentaires">
+          <h3 class="arcade-legend__title">Légende</h3>
+          <dl class="arcade-legend__list">
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">q</dt>
+              <dd class="arcade-legend__description">Quark</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">e⁻</dt>
+              <dd class="arcade-legend__description">Électron</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">ν</dt>
+              <dd class="arcade-legend__description">Neutrino</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">g</dt>
+              <dd class="arcade-legend__description">Gluon</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">γ</dt>
+              <dd class="arcade-legend__description">Photon</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">W±</dt>
+              <dd class="arcade-legend__description">Boson W</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">Z⁰</dt>
+              <dd class="arcade-legend__description">Boson Z</dd>
+            </div>
+            <div class="arcade-legend__item">
+              <dt class="arcade-legend__symbol">H</dt>
+              <dd class="arcade-legend__description">Boson de Higgs</dd>
+            </div>
+          </dl>
+        </aside>
       </div>
     </section>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -676,8 +676,9 @@ body.theme-neon .arcade-header__status--info {
 
 .arcade-content {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
   flex: 1 1 auto;
   width: 100%;
   padding-block: var(--arcade-stage-spacing);
@@ -700,6 +701,59 @@ body.theme-neon .arcade-header__status--info {
   box-shadow: 0 32px 68px rgba(6, 8, 28, 0.55);
 }
 
+.arcade-stage {
+  align-self: center;
+}
+
+.arcade-legend {
+  flex: 0 0 clamp(120px, 13vw, 180px);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: clamp(0.75rem, 1.6vw, 1.1rem);
+  padding: clamp(0.75rem, 1.4vw, 1rem);
+  border-radius: 1.2rem;
+  border: 1px solid rgba(120, 190, 255, 0.2);
+  background: linear-gradient(180deg, rgba(18, 26, 64, 0.85), rgba(10, 16, 44, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(120, 190, 255, 0.1);
+  color: rgba(220, 232, 255, 0.95);
+  text-align: left;
+}
+
+.arcade-legend__title {
+  margin: 0;
+  font-size: clamp(0.8rem, 1.2vw, 0.95rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(175, 205, 255, 0.9);
+}
+
+.arcade-legend__list {
+  margin: 0;
+  display: grid;
+  gap: clamp(0.4rem, 1.1vw, 0.8rem);
+  padding: 0;
+}
+
+.arcade-legend__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: clamp(0.35rem, 0.8vw, 0.6rem);
+  align-items: baseline;
+}
+
+.arcade-legend__symbol {
+  font-size: clamp(0.95rem, 1.8vw, 1.3rem);
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.98);
+}
+
+.arcade-legend__description {
+  margin: 0;
+  font-size: clamp(0.68rem, 1vw, 0.82rem);
+  color: rgba(200, 215, 240, 0.92);
+}
+
 @media (max-width: 960px) {
   .arcade-stage {
     width: min(
@@ -707,12 +761,41 @@ body.theme-neon .arcade-header__status--info {
       max(360px, calc((100vh - var(--arcade-vertical-offset)) * 1.6))
     );
   }
+  .arcade-content {
+    flex-direction: column;
+    align-items: center;
+  }
+  .arcade-legend {
+    width: min(100%, 420px);
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: clamp(0.5rem, 2.5vw, 1rem);
+    border-radius: 1rem;
+  }
+  .arcade-legend__list {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: clamp(0.45rem, 2vw, 0.9rem);
+  }
+  .arcade-legend__item {
+    grid-template-columns: auto;
+    text-align: center;
+  }
 }
 
 @media (max-width: 640px) {
   .arcade-stage {
     width: calc(100vw - var(--arcade-padding-x) * 2);
     max-height: calc((100vw - var(--arcade-padding-x) * 2) / 1.6);
+  }
+  .arcade-legend__symbol {
+    font-size: clamp(0.85rem, 4vw, 1.1rem);
+  }
+  .arcade-legend__description {
+    font-size: clamp(0.64rem, 3.5vw, 0.78rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a particle legend panel to the Particules arcade section with symbol and description pairs
- style the legend to sit alongside the game canvas on desktop and adapt responsively on smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6533b78d8832ebbf7cf377e4aaa4f