### PR TITLE
Add particle rain effects for arcade brick destruction

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
             aria-label="Zone de jeu Particules"
             role="presentation"
           ></canvas>
+          <div class="arcade-particle-layer" id="arcadeParticleLayer" aria-hidden="true"></div>
           <div class="arcade-overlay" id="arcadeOverlay" role="dialog" aria-modal="false" hidden>
             <div class="arcade-overlay__content">
               <p class="arcade-overlay__message" id="arcadeOverlayMessage">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1542,6 +1542,7 @@ const elements = {
   arcadeBonusTicketDisplay: document.getElementById('arcadeBonusTicketDisplay'),
   arcadeBonusTicketValue: document.getElementById('arcadeBonusTicketValue'),
   arcadeCanvas: document.getElementById('arcadeGameCanvas'),
+  arcadeParticleLayer: document.getElementById('arcadeParticleLayer'),
   arcadeOverlay: document.getElementById('arcadeOverlay'),
   arcadeOverlayMessage: document.getElementById('arcadeOverlayMessage'),
   arcadeOverlayButton: document.getElementById('arcadeOverlayButton'),

--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -1822,6 +1822,7 @@ function initParticulesGame() {
   }
   particulesGame = new ParticulesGame({
     canvas: elements.arcadeCanvas,
+    particleLayer: elements.arcadeParticleLayer,
     overlay: elements.arcadeOverlay,
     overlayButton: elements.arcadeOverlayButton,
     overlayMessage: elements.arcadeOverlayMessage,

--- a/styles/main.css
+++ b/styles/main.css
@@ -817,6 +817,48 @@ body.theme-neon .arcade-header__status--info {
   cursor: pointer;
 }
 
+.arcade-particle-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  overflow: hidden;
+}
+
+.arcade-particle {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  opacity: 0;
+  border-radius: 1px;
+  background: linear-gradient(135deg, hsla(210, 95%, 75%, 0.95), hsla(265, 80%, 60%, 0.5));
+  mix-blend-mode: screen;
+  will-change: transform, opacity;
+  transform: translate3d(0, 0, 0) scale(var(--arcade-particle-scale-start, 1));
+  animation: arcade-particle-fall var(--arcade-particle-duration, 2s)
+    cubic-bezier(0.2, 0.7, 0.3, 1) forwards;
+}
+
+@keyframes arcade-particle-fall {
+  0% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(var(--arcade-particle-scale-start, 1)) rotate(0deg);
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(
+        var(--arcade-particle-dx, 0px),
+        var(--arcade-particle-dy, 140px),
+        0
+      )
+      scale(var(--arcade-particle-scale-end, 0.45))
+      rotate(var(--arcade-particle-rotation, 35deg));
+  }
+}
+
 .arcade-stage__hud {
   position: absolute;
   bottom: clamp(0.4rem, 1.6vw, 1.2rem);


### PR DESCRIPTION
## Summary
- add an overlay particle layer and styles for arcade-stage brick impact effects
- spawn flashy falling particles when bricks break and clean them up between levels
- connect the particle layer to the Particules game initialization

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d766573458832e97d794dd341ad9c8