### PR TITLE
Remove particle rain effect for brick impacts

### DIFF
--- a/scripts/particules.js
+++ b/scripts/particules.js
@@ -1404,7 +1404,6 @@
       const brickHeight = brick.relHeight * rect.height;
       const brickCenterX = brickLeft + brickWidth / 2;
       const brickCenterY = brickTop + brickHeight / 2;
-      const distanceToBottom = Math.max(60, rect.height - brickCenterY);
       const baseCount = Math.max(14, Math.round(18 + Math.random() * 10));
       const maxHorizontalScatter = Math.min(rect.width * 0.2, 180);
 
@@ -1430,13 +1429,8 @@
         const burstAngle = Math.random() * Math.PI * 2;
         const burstX = clamp(Math.cos(burstAngle) * burstRadius, -maxHorizontalScatter, maxHorizontalScatter);
         const burstY = -Math.abs(Math.sin(burstAngle)) * (burstRadius * 0.82 + Math.random() * 34) - (16 + Math.random() * 28);
-        const sway = (Math.random() - 0.5) * burstRadius * 0.45;
-        const fallDistance = Math.min(rect.height * 0.95, Math.max(140, distanceToBottom * (0.65 + Math.random() * 0.55) + 90));
-        const finalDx = clamp(burstX * (0.35 + Math.random() * 0.4) + sway, -maxHorizontalScatter * 1.3, maxHorizontalScatter * 1.3);
         particle.style.setProperty('--arcade-particle-burst-x', `${burstX.toFixed(2)}px`);
         particle.style.setProperty('--arcade-particle-burst-y', `${burstY.toFixed(2)}px`);
-        particle.style.setProperty('--arcade-particle-dx', `${(burstX + finalDx).toFixed(2)}px`);
-        particle.style.setProperty('--arcade-particle-dy', `${fallDistance.toFixed(2)}px`);
         const scaleStart = 0.6 + Math.random() * 0.4;
         const peakScale = scaleStart + 0.3 + Math.random() * 0.25;
         const scaleEnd = 0.35 + Math.random() * 0.25;
@@ -1444,8 +1438,8 @@
         particle.style.setProperty('--arcade-particle-scale-peak', peakScale.toFixed(2));
         particle.style.setProperty('--arcade-particle-scale-end', scaleEnd.toFixed(2));
         particle.style.setProperty('--arcade-particle-rotation', `${((Math.random() - 0.5) * 220).toFixed(1)}deg`);
-        const duration = 2000 + Math.random() * 720;
-        particle.style.setProperty('--arcade-particle-duration', `${duration.toFixed(0)}ms`);
+        const duration = 1500;
+        particle.style.setProperty('--arcade-particle-duration', `${duration}ms`);
         particle.style.animationDelay = `${Math.random() * 130}ms`;
         const removeParticle = () => {
           particle.removeEventListener('animationend', removeParticle);

--- a/styles/main.css
+++ b/styles/main.css
@@ -866,17 +866,17 @@ body.theme-neon .arcade-header__status--info {
   mix-blend-mode: screen;
   will-change: transform, opacity;
   transform: translate3d(0, 0, 0) scale(var(--arcade-particle-scale-start, 1));
-  animation: arcade-particle-fall var(--arcade-particle-duration, 2s)
+  animation: arcade-particle-burst var(--arcade-particle-duration, 1.5s)
     cubic-bezier(0.18, 0.58, 0.28, 1) forwards;
 }
 
-@keyframes arcade-particle-fall {
+@keyframes arcade-particle-burst {
   0% {
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(var(--arcade-particle-scale-start, 1))
       rotate(var(--arcade-particle-rotation, 35deg));
   }
-  35% {
+  45% {
     opacity: 1;
     transform: translate3d(
         var(--arcade-particle-burst-x, 0px),
@@ -886,14 +886,25 @@ body.theme-neon .arcade-header__status--info {
       scale(var(--arcade-particle-scale-peak, 1.15))
       rotate(var(--arcade-particle-rotation, 35deg));
   }
-  60% {
-    opacity: 0.92;
+  70% {
+    opacity: 0.9;
+    transform: translate3d(
+        var(--arcade-particle-burst-x, 0px),
+        var(--arcade-particle-burst-y, -80px),
+        0
+      )
+      scale(
+        calc(
+          (var(--arcade-particle-scale-peak, 1.15) + var(--arcade-particle-scale-end, 0.45)) / 2
+        )
+      )
+      rotate(var(--arcade-particle-rotation, 35deg));
   }
   100% {
     opacity: 0;
     transform: translate3d(
-        var(--arcade-particle-dx, 0px),
-        var(--arcade-particle-dy, 140px),
+        var(--arcade-particle-burst-x, 0px),
+        var(--arcade-particle-burst-y, -80px),
         0
       )
       scale(var(--arcade-particle-scale-end, 0.45))


### PR DESCRIPTION
## Summary
- simplify the particle impact spawn logic to remove the falling phase and enforce a 1.5s lifetime
- update the arcade particle animation to keep only the burst effect before fading out

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7701df354832e8964ffe080cdf5fa