### PR TITLE
Improve sound designer overlay responsiveness

### DIFF
--- a/scripts/modules/sound-designer.js
+++ b/scripts/modules/sound-designer.js
@@ -592,6 +592,7 @@
 
   renderPresetList();
   resetForm();
+  closeOverlay();
 
   if (statusElement) {
     statusElement.textContent = window.Tone && window.Tone.isSupported !== false

--- a/styles/main.css
+++ b/styles/main.css
@@ -3602,12 +3602,17 @@ body.devkit-open {
   position: fixed;
   inset: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: clamp(1rem, 4vw, 2.5rem);
+  padding: clamp(1rem, 6vw, 3rem) clamp(0.75rem, 4vw, 2.5rem);
   background: rgba(5, 8, 16, 0.86);
   backdrop-filter: blur(12px);
   z-index: 90;
+  overflow-y: auto;
+}
+
+.sound-designer-overlay[hidden] {
+  display: none !important;
 }
 
 .sound-designer-panel {
@@ -3621,6 +3626,9 @@ body.devkit-open {
   flex-direction: column;
   gap: 1.2rem;
   padding: clamp(1.2rem, 2vw, 1.8rem);
+  max-height: min(720px, 92vh);
+  overflow-y: auto;
+  margin: 0 auto;
 }
 
 .sound-designer-panel__header {


### PR DESCRIPTION
## Summary
- ensure the sound designer overlay is explicitly closed after initialization
- adjust the overlay layout to support scrolling and better sizing on smaller screens

## Testing
- Manually loaded http://127.0.0.1:8000/index.html and opened the sound designer overlay

------
https://chatgpt.com/codex/tasks/task_e_68d795cc5cb4832e97f975b04cbed0ea