### PR TITLE
Add Métaux match-3 mini game

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,6 +375,53 @@
       </div>
     </section>
 
+    <section id="metaux" class="page page--metaux" aria-label="Métaux" hidden>
+      <header class="metaux-header" aria-label="Navigation du jeu Métaux">
+        <button class="metaux-header__brand brand brand-button" id="metauxReturnButton" type="button">
+          Métaux
+        </button>
+        <div class="metaux-header__stats" role="status" aria-live="polite">
+          <div class="metaux-stat">
+            <span class="metaux-stat__label">Dernier combo</span>
+            <span class="metaux-stat__value" id="metauxLastComboValue">0</span>
+          </div>
+          <div class="metaux-stat">
+            <span class="metaux-stat__label">Meilleur combo</span>
+            <span class="metaux-stat__value" id="metauxBestComboValue">0</span>
+          </div>
+          <div class="metaux-stat">
+            <span class="metaux-stat__label">Coups joués</span>
+            <span class="metaux-stat__value" id="metauxMovesValue">0</span>
+          </div>
+        </div>
+      </header>
+      <div class="metaux-content">
+        <div class="metaux-board-wrapper">
+          <div class="metaux-board" id="metauxBoard" role="grid" aria-label="Grille du mini-jeu Métaux"></div>
+          <p class="metaux-message" id="metauxMessage" role="status" aria-live="polite"></p>
+        </div>
+        <aside class="metaux-sidebar" aria-label="Suivi des métaux">
+          <h3 class="metaux-sidebar__title">Forge quantique</h3>
+          <p class="metaux-sidebar__intro">
+            Alignez au moins trois lingots identiques pour les raffiner et déclencher des réactions en cascade.
+          </p>
+          <dl class="metaux-sidebar__stats">
+            <div class="metaux-sidebar__stat">
+              <dt>Total de tuiles fondues</dt>
+              <dd id="metauxTotalTilesValue">0</dd>
+            </div>
+            <div class="metaux-sidebar__stat">
+              <dt>Re-mélanges</dt>
+              <dd id="metauxReshufflesValue">0</dd>
+            </div>
+          </dl>
+          <button type="button" class="metaux-reshuffle-button" id="metauxReshuffleButton">
+            Re-mélanger
+          </button>
+        </aside>
+      </div>
+    </section>
+
     <section id="goals" class="page" aria-labelledby="goals-title">
       <h2 id="goals-title">Objectifs &amp; trophées</h2>
       <p class="section-intro">Surveillez vos succès galactiques et débloquez des bonus permanents.</p>
@@ -427,6 +474,16 @@
           <div class="option-row">
             <button type="button" id="soundDesignerOpenButton" class="primary">Ouvrir le studio</button>
             <span class="option-note" id="soundDesignerStatus" role="status"></span>
+          </div>
+        </div>
+        <div class="option-card option-card--minigame">
+          <h3>Mini-jeux</h3>
+          <p class="option-note">
+            Expérimentez de nouvelles mécaniques inspirées du laboratoire principal.
+          </p>
+          <div class="option-row">
+            <button type="button" id="metauxOpenButton" class="primary">Lancer Métaux</button>
+            <span class="option-note" id="metauxOptionStatus" role="status"></span>
           </div>
         </div>
         <div class="option-card" id="bigBangOptionCard" hidden>
@@ -630,6 +687,7 @@
   <script src="scripts/modules/gacha.js"></script>
   <script src="scripts/modules/info.js"></script>
   <script src="scripts/modules/sound-designer.js"></script>
+  <script src="scripts/modules/metaux-match3.js"></script>
   <script src="scripts/app.js"></script>
 </body>
 </html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1550,6 +1550,17 @@ const elements = {
   arcadeLivesValue: document.getElementById('arcadeLivesValue'),
   arcadeScoreValue: document.getElementById('arcadeScoreValue'),
   arcadeComboMessage: document.getElementById('arcadeComboMessage'),
+  metauxOpenButton: document.getElementById('metauxOpenButton'),
+  metauxOptionStatus: document.getElementById('metauxOptionStatus'),
+  metauxReturnButton: document.getElementById('metauxReturnButton'),
+  metauxBoard: document.getElementById('metauxBoard'),
+  metauxLastComboValue: document.getElementById('metauxLastComboValue'),
+  metauxBestComboValue: document.getElementById('metauxBestComboValue'),
+  metauxTotalTilesValue: document.getElementById('metauxTotalTilesValue'),
+  metauxReshufflesValue: document.getElementById('metauxReshufflesValue'),
+  metauxMovesValue: document.getElementById('metauxMovesValue'),
+  metauxMessage: document.getElementById('metauxMessage'),
+  metauxReshuffleButton: document.getElementById('metauxReshuffleButton'),
   themeSelect: document.getElementById('themeSelect'),
   musicTrackSelect: document.getElementById('musicTrackSelect'),
   musicTrackStatus: document.getElementById('musicTrackStatus'),
@@ -4209,11 +4220,19 @@ function showPage(pageId) {
   document.body.dataset.activePage = pageId;
   document.body.classList.toggle('view-game', pageId === 'game');
   document.body.classList.toggle('view-arcade', pageId === 'arcade');
+  document.body.classList.toggle('view-metaux', pageId === 'metaux');
   if (particulesGame) {
     if (pageId === 'arcade') {
       particulesGame.onEnter();
     } else {
       particulesGame.onLeave();
+    }
+  }
+  if (metauxGame) {
+    if (pageId === 'metaux') {
+      metauxGame.onEnter();
+    } else {
+      metauxGame.onLeave();
     }
   }
   if (pageId === 'game' && (typeof document === 'undefined' || !document.hidden)) {
@@ -4375,6 +4394,7 @@ document.addEventListener('keydown', event => {
 updateDevKitUI();
 
 initParticulesGame();
+initMetauxGame();
 
 elements.navButtons.forEach(btn => {
   btn.addEventListener('click', () => {
@@ -4385,6 +4405,32 @@ elements.navButtons.forEach(btn => {
     showPage(target);
   });
 });
+
+if (elements.metauxOpenButton) {
+  elements.metauxOpenButton.addEventListener('click', () => {
+    initMetauxGame();
+    showPage('metaux');
+  });
+}
+
+if (elements.metauxReturnButton) {
+  elements.metauxReturnButton.addEventListener('click', () => {
+    showPage('options');
+  });
+}
+
+if (elements.metauxReshuffleButton) {
+  elements.metauxReshuffleButton.addEventListener('click', () => {
+    initMetauxGame();
+    if (metauxGame) {
+      if (metauxGame.processing) {
+        metauxGame.updateMessage('Patientez, la réaction en chaîne est en cours.');
+        return;
+      }
+      metauxGame.forceReshuffle(true);
+    }
+  });
+}
 
 if (elements.brandPortal) {
   elements.brandPortal.addEventListener('click', () => {

--- a/scripts/modules/metaux-match3.js
+++ b/scripts/modules/metaux-match3.js
@@ -1,0 +1,649 @@
+const METAUX_TILE_TYPES = [
+  { id: 'bronze', label: 'Bronze' },
+  { id: 'argent', label: 'Argent' },
+  { id: 'or', label: 'Or' },
+  { id: 'platine', label: 'Platine' },
+  { id: 'diamant', label: 'Diamant' }
+];
+
+const METAUX_ROWS = 18;
+const METAUX_COLS = 32;
+const METAUX_CLEAR_DELAY = 200;
+const METAUX_MAX_SHUFFLE_ATTEMPTS = 120;
+const METAUX_TILE_CLASSES = METAUX_TILE_TYPES.map(type => `metaux-tile--${type.id}`);
+
+class MetauxMatch3Game {
+  constructor(options = {}) {
+    this.boardElement = options.boardElement || null;
+    this.lastComboElement = options.lastComboElement || null;
+    this.bestComboElement = options.bestComboElement || null;
+    this.totalTilesElement = options.totalTilesElement || null;
+    this.reshufflesElement = options.reshufflesElement || null;
+    this.movesElement = options.movesElement || null;
+    this.messageElement = options.messageElement || null;
+    this.optionStatusElement = options.optionStatusElement || null;
+    this.board = Array.from({ length: METAUX_ROWS }, () => Array(METAUX_COLS).fill(null));
+    this.tiles = Array.from({ length: METAUX_ROWS }, () => Array(METAUX_COLS).fill(null));
+    this.initialized = false;
+    this.processing = false;
+    this.dragState = null;
+    this.comboChain = 0;
+    this.stats = {
+      lastCombo: 0,
+      bestCombo: 0,
+      totalCleared: 0,
+      reshuffles: 0,
+      moves: 0
+    };
+    this.boundPointerDown = this.onPointerDown.bind(this);
+    this.boundPointerMove = this.onPointerMove.bind(this);
+    this.boundPointerUp = this.onPointerUp.bind(this);
+    this.boundPointerCancel = this.onPointerCancel.bind(this);
+  }
+
+  initialize() {
+    if (this.initialized || !this.boardElement) {
+      return;
+    }
+    this.buildBoard();
+    this.populateBoard();
+    this.refreshBoard();
+    this.updateStats();
+    this.updateMessage('Glissez pour échanger des lingots adjacents.');
+    this.initialized = true;
+  }
+
+  onEnter() {
+    if (!this.initialized) {
+      this.initialize();
+    } else if (this.boardElement) {
+      this.updateMessage('Repérez un alignement et glissez pour fusionner les métaux.');
+    }
+  }
+
+  onLeave() {
+    this.clearDragState();
+  }
+
+  buildBoard() {
+    if (!this.boardElement) {
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      for (let col = 0; col < METAUX_COLS; col += 1) {
+        const tile = document.createElement('div');
+        tile.className = 'metaux-tile is-empty';
+        tile.dataset.row = String(row);
+        tile.dataset.col = String(col);
+        tile.setAttribute('role', 'button');
+        tile.setAttribute('tabindex', '-1');
+        tile.addEventListener('pointerdown', this.boundPointerDown);
+        tile.addEventListener('pointermove', this.boundPointerMove);
+        tile.addEventListener('pointerup', this.boundPointerUp);
+        tile.addEventListener('pointercancel', this.boundPointerCancel);
+        tile.addEventListener('contextmenu', event => {
+          event.preventDefault();
+        });
+        tile.addEventListener('dragstart', event => {
+          event.preventDefault();
+        });
+        const label = document.createElement('span');
+        tile.appendChild(label);
+        tile._label = label;
+        this.tiles[row][col] = tile;
+        fragment.appendChild(tile);
+      }
+    }
+    this.boardElement.innerHTML = '';
+    this.boardElement.appendChild(fragment);
+  }
+
+  populateBoard() {
+    let attempts = 0;
+    do {
+      attempts += 1;
+      this.fillRandomBoard();
+    } while ((this.hasExistingMatches() || !this.hasAvailableMoves()) && attempts < METAUX_MAX_SHUFFLE_ATTEMPTS);
+    if (attempts >= METAUX_MAX_SHUFFLE_ATTEMPTS) {
+      this.fillRandomBoard();
+    }
+  }
+
+  fillRandomBoard() {
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      for (let col = 0; col < METAUX_COLS; col += 1) {
+        this.board[row][col] = this.generateTileFor(row, col);
+      }
+    }
+  }
+
+  generateTileFor(row, col) {
+    let choice = null;
+    let safety = 0;
+    while (!choice && safety < 24) {
+      safety += 1;
+      const candidate = METAUX_TILE_TYPES[Math.floor(Math.random() * METAUX_TILE_TYPES.length)].id;
+      if (this.createsImmediateMatch(row, col, candidate)) {
+        continue;
+      }
+      choice = candidate;
+    }
+    return choice || METAUX_TILE_TYPES[0].id;
+  }
+
+  createsImmediateMatch(row, col, type) {
+    if (!type) {
+      return false;
+    }
+    const left1 = col > 0 ? this.board[row][col - 1] : null;
+    const left2 = col > 1 ? this.board[row][col - 2] : null;
+    if (left1 === type && left2 === type) {
+      return true;
+    }
+    const up1 = row > 0 ? this.board[row - 1][col] : null;
+    const up2 = row > 1 ? this.board[row - 2][col] : null;
+    if (up1 === type && up2 === type) {
+      return true;
+    }
+    return false;
+  }
+
+  refreshBoard() {
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      for (let col = 0; col < METAUX_COLS; col += 1) {
+        this.updateTileElement(row, col, this.board[row][col]);
+      }
+    }
+  }
+
+  updateTileElement(row, col, type) {
+    const tile = this.tiles[row][col];
+    if (!tile) {
+      return;
+    }
+    tile.classList.remove('is-selected', 'is-target', 'is-clearing', 'is-empty');
+    METAUX_TILE_CLASSES.forEach(cls => {
+      tile.classList.remove(cls);
+    });
+    tile.dataset.type = type || '';
+    const labelElement = tile._label || tile.firstElementChild;
+    if (!type) {
+      tile.classList.add('is-empty');
+      if (labelElement) {
+        labelElement.textContent = '';
+      }
+      tile.setAttribute('aria-label', 'Case vide');
+      return;
+    }
+    tile.classList.add(`metaux-tile--${type}`);
+    const label = this.getTypeLabel(type);
+    if (labelElement) {
+      labelElement.textContent = label;
+    }
+    tile.setAttribute('aria-label', label);
+  }
+
+  getTypeLabel(type) {
+    const found = METAUX_TILE_TYPES.find(entry => entry.id === type);
+    return found ? found.label : type;
+  }
+
+  onPointerDown(event) {
+    if (this.processing) {
+      return;
+    }
+    const tile = event.currentTarget;
+    const row = Number(tile.dataset.row);
+    const col = Number(tile.dataset.col);
+    if (!Number.isInteger(row) || !Number.isInteger(col)) {
+      return;
+    }
+    const type = this.board[row][col];
+    if (!type) {
+      return;
+    }
+    event.preventDefault();
+    const rect = this.boardElement ? this.boardElement.getBoundingClientRect() : { width: 0 };
+    const threshold = Math.max(rect.width / METAUX_COLS / 2, 10);
+    this.clearDragState();
+    this.dragState = {
+      row,
+      col,
+      tile,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      threshold,
+      target: null
+    };
+    if (tile.setPointerCapture) {
+      tile.setPointerCapture(event.pointerId);
+    }
+    tile.classList.add('is-selected');
+  }
+
+  onPointerMove(event) {
+    if (!this.dragState || this.processing) {
+      return;
+    }
+    const dx = event.clientX - this.dragState.startX;
+    const dy = event.clientY - this.dragState.startY;
+    if (Math.abs(dx) < this.dragState.threshold && Math.abs(dy) < this.dragState.threshold) {
+      this.setHoverTarget(null);
+      return;
+    }
+    let targetRow = this.dragState.row;
+    let targetCol = this.dragState.col;
+    if (Math.abs(dx) > Math.abs(dy)) {
+      targetCol += dx > 0 ? 1 : -1;
+    } else {
+      targetRow += dy > 0 ? 1 : -1;
+    }
+    if (!this.isValidPosition(targetRow, targetCol) || !this.board[targetRow][targetCol]) {
+      this.setHoverTarget(null);
+      return;
+    }
+    if (!this.dragState.target || this.dragState.target.row !== targetRow || this.dragState.target.col !== targetCol) {
+      const tile = this.tiles[targetRow][targetCol];
+      this.setHoverTarget({ row: targetRow, col: targetCol, tile });
+    }
+  }
+
+  onPointerUp(event) {
+    if (!this.dragState) {
+      return;
+    }
+    event.preventDefault();
+    const origin = { row: this.dragState.row, col: this.dragState.col };
+    const target = this.dragState.target ? { row: this.dragState.target.row, col: this.dragState.target.col } : null;
+    const pointerId = this.dragState.pointerId;
+    const originTile = this.dragState.tile;
+    this.clearDragState();
+    if (originTile && originTile.releasePointerCapture && pointerId != null) {
+      originTile.releasePointerCapture(pointerId);
+    }
+    if (target) {
+      this.attemptSwap(origin, target);
+    } else {
+      this.updateMessage('Sélectionnez un lingot adjacent pour forger un match.');
+    }
+  }
+
+  onPointerCancel() {
+    if (!this.dragState) {
+      return;
+    }
+    const pointerId = this.dragState.pointerId;
+    const originTile = this.dragState.tile;
+    this.clearDragState();
+    if (originTile && originTile.releasePointerCapture && pointerId != null) {
+      originTile.releasePointerCapture(pointerId);
+    }
+  }
+
+  setHoverTarget(target) {
+    if (this.dragState?.target?.tile && (!target || this.dragState.target.tile !== target.tile)) {
+      this.dragState.target.tile.classList.remove('is-target');
+    }
+    if (target && target.tile) {
+      target.tile.classList.add('is-target');
+      this.dragState.target = target;
+    } else if (this.dragState) {
+      this.dragState.target = null;
+    }
+  }
+
+  clearDragState() {
+    if (this.dragState?.tile) {
+      this.dragState.tile.classList.remove('is-selected');
+    }
+    if (this.dragState?.target?.tile) {
+      this.dragState.target.tile.classList.remove('is-target');
+    }
+    this.dragState = null;
+  }
+
+  attemptSwap(origin, target) {
+    if (this.processing) {
+      return;
+    }
+    if (!this.isAdjacent(origin, target)) {
+      this.updateMessage('Déplacez-vous seulement vers une case voisine.');
+      return;
+    }
+    this.processing = true;
+    this.swapTiles(origin, target);
+    this.updateTileElement(origin.row, origin.col, this.board[origin.row][origin.col]);
+    this.updateTileElement(target.row, target.col, this.board[target.row][target.col]);
+    const matches = this.findMatches();
+    if (!matches.length) {
+      this.swapTiles(origin, target);
+      this.updateTileElement(origin.row, origin.col, this.board[origin.row][origin.col]);
+      this.updateTileElement(target.row, target.col, this.board[target.row][target.col]);
+      this.processing = false;
+      this.updateMessage('Aucun alignement créé, échange annulé.');
+      return;
+    }
+    this.stats.moves += 1;
+    this.startCascade(matches);
+  }
+
+  startCascade(initialMatches) {
+    this.comboChain = 0;
+    this.resolveCascade(initialMatches);
+  }
+
+  resolveCascade(matches) {
+    if (!matches.length) {
+      this.finishCascade();
+      return;
+    }
+    this.comboChain += 1;
+    this.stats.totalCleared += matches.length;
+    matches.forEach(position => {
+      const tile = this.tiles[position.row][position.col];
+      if (tile) {
+        tile.classList.add('is-clearing');
+      }
+    });
+    window.setTimeout(() => {
+      matches.forEach(position => {
+        this.board[position.row][position.col] = null;
+        this.updateTileElement(position.row, position.col, null);
+      });
+      this.applyGravity();
+      this.fillEmptySpaces();
+      this.refreshBoard();
+      const nextMatches = this.findMatches();
+      if (nextMatches.length) {
+        this.resolveCascade(nextMatches);
+      } else {
+        this.finishCascade();
+      }
+    }, METAUX_CLEAR_DELAY);
+  }
+
+  finishCascade() {
+    this.stats.lastCombo = this.comboChain;
+    if (this.comboChain > this.stats.bestCombo) {
+      this.stats.bestCombo = this.comboChain;
+    }
+    this.updateStats();
+    if (this.comboChain > 1) {
+      this.updateMessage(`Combo x${this.comboChain} ! Réaction en chaîne réussie.`);
+    } else if (this.comboChain === 1) {
+      this.updateMessage('Alignement complet ! De nouveaux lingots tombent.');
+    }
+    this.comboChain = 0;
+    this.processing = false;
+    if (!this.hasAvailableMoves()) {
+      this.forceReshuffle(false);
+    }
+  }
+
+  applyGravity() {
+    for (let col = 0; col < METAUX_COLS; col += 1) {
+      let writeRow = METAUX_ROWS - 1;
+      for (let row = METAUX_ROWS - 1; row >= 0; row -= 1) {
+        const value = this.board[row][col];
+        if (value) {
+          this.board[writeRow][col] = value;
+          if (writeRow !== row) {
+            this.board[row][col] = null;
+          }
+          writeRow -= 1;
+        }
+      }
+      for (let fillRow = writeRow; fillRow >= 0; fillRow -= 1) {
+        this.board[fillRow][col] = null;
+      }
+    }
+  }
+
+  fillEmptySpaces() {
+    for (let col = 0; col < METAUX_COLS; col += 1) {
+      for (let row = 0; row < METAUX_ROWS; row += 1) {
+        if (!this.board[row][col]) {
+          this.board[row][col] = this.generateTileFor(row, col);
+        }
+      }
+    }
+  }
+
+  findMatches() {
+    const matches = [];
+    const seen = new Set();
+    const mark = (row, col) => {
+      const key = `${row},${col}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        matches.push({ row, col });
+      }
+    };
+    // Horizontal
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      let streakType = null;
+      let streakLength = 0;
+      for (let col = 0; col <= METAUX_COLS; col += 1) {
+        const current = col < METAUX_COLS ? this.board[row][col] : null;
+        if (current && current === streakType) {
+          streakLength += 1;
+        } else {
+          if (streakType && streakLength >= 3) {
+            for (let offset = 1; offset <= streakLength; offset += 1) {
+              mark(row, col - offset);
+            }
+          }
+          streakType = current;
+          streakLength = current ? 1 : 0;
+        }
+      }
+    }
+    // Vertical
+    for (let col = 0; col < METAUX_COLS; col += 1) {
+      let streakType = null;
+      let streakLength = 0;
+      for (let row = 0; row <= METAUX_ROWS; row += 1) {
+        const current = row < METAUX_ROWS ? this.board[row][col] : null;
+        if (current && current === streakType) {
+          streakLength += 1;
+        } else {
+          if (streakType && streakLength >= 3) {
+            for (let offset = 1; offset <= streakLength; offset += 1) {
+              mark(row - offset, col);
+            }
+          }
+          streakType = current;
+          streakLength = current ? 1 : 0;
+        }
+      }
+    }
+    return matches;
+  }
+
+  hasExistingMatches() {
+    return this.findMatches().length > 0;
+  }
+
+  hasAvailableMoves() {
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      for (let col = 0; col < METAUX_COLS; col += 1) {
+        const current = this.board[row][col];
+        if (!current) {
+          continue;
+        }
+        const right = { row, col: col + 1 };
+        const down = { row: row + 1, col };
+        if (this.isValidPosition(right.row, right.col) && this.wouldCreateMatch({ row, col }, right)) {
+          return true;
+        }
+        if (this.isValidPosition(down.row, down.col) && this.wouldCreateMatch({ row, col }, down)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  wouldCreateMatch(origin, target) {
+    if (!this.isValidPosition(origin.row, origin.col) || !this.isValidPosition(target.row, target.col)) {
+      return false;
+    }
+    this.swapTiles(origin, target);
+    const result = this.hasMatchAt(origin.row, origin.col) || this.hasMatchAt(target.row, target.col);
+    this.swapTiles(origin, target);
+    return result;
+  }
+
+  hasMatchAt(row, col) {
+    const type = this.board[row][col];
+    if (!type) {
+      return false;
+    }
+    const horizontal = 1 + this.countDirection(row, col, 0, -1, type) + this.countDirection(row, col, 0, 1, type);
+    if (horizontal >= 3) {
+      return true;
+    }
+    const vertical = 1 + this.countDirection(row, col, -1, 0, type) + this.countDirection(row, col, 1, 0, type);
+    return vertical >= 3;
+  }
+
+  countDirection(row, col, deltaRow, deltaCol, type) {
+    let count = 0;
+    let currentRow = row + deltaRow;
+    let currentCol = col + deltaCol;
+    while (this.isValidPosition(currentRow, currentCol) && this.board[currentRow][currentCol] === type) {
+      count += 1;
+      currentRow += deltaRow;
+      currentCol += deltaCol;
+    }
+    return count;
+  }
+
+  swapTiles(a, b) {
+    const temp = this.board[a.row][a.col];
+    this.board[a.row][a.col] = this.board[b.row][b.col];
+    this.board[b.row][b.col] = temp;
+  }
+
+  isAdjacent(a, b) {
+    const rowDelta = Math.abs(a.row - b.row);
+    const colDelta = Math.abs(a.col - b.col);
+    return (rowDelta === 1 && colDelta === 0) || (rowDelta === 0 && colDelta === 1);
+  }
+
+  isValidPosition(row, col) {
+    return row >= 0 && row < METAUX_ROWS && col >= 0 && col < METAUX_COLS;
+  }
+
+  forceReshuffle(manual = true) {
+    if (!this.initialized) {
+      this.initialize();
+    }
+    const pool = [];
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      for (let col = 0; col < METAUX_COLS; col += 1) {
+        pool.push(this.board[row][col]);
+      }
+    }
+    let attempts = 0;
+    let success = false;
+    while (attempts < METAUX_MAX_SHUFFLE_ATTEMPTS && !success) {
+      attempts += 1;
+      shuffleArray(pool);
+      this.assignFromArray(pool);
+      if (!this.hasExistingMatches() && this.hasAvailableMoves()) {
+        success = true;
+      }
+    }
+    if (!success) {
+      this.populateBoard();
+    }
+    this.refreshBoard();
+    this.stats.reshuffles += 1;
+    this.updateStats();
+    this.updateMessage(manual ? 'Grille re-mélangée.' : 'Aucun coup possible, réorganisation automatique.');
+  }
+
+  assignFromArray(values) {
+    let index = 0;
+    for (let row = 0; row < METAUX_ROWS; row += 1) {
+      for (let col = 0; col < METAUX_COLS; col += 1) {
+        this.board[row][col] = values[index % values.length] || METAUX_TILE_TYPES[0].id;
+        index += 1;
+      }
+    }
+  }
+
+  updateStats() {
+    if (this.lastComboElement) {
+      this.lastComboElement.textContent = this.stats.lastCombo.toLocaleString('fr-FR');
+    }
+    if (this.bestComboElement) {
+      this.bestComboElement.textContent = this.stats.bestCombo.toLocaleString('fr-FR');
+    }
+    if (this.totalTilesElement) {
+      this.totalTilesElement.textContent = this.stats.totalCleared.toLocaleString('fr-FR');
+    }
+    if (this.reshufflesElement) {
+      this.reshufflesElement.textContent = this.stats.reshuffles.toLocaleString('fr-FR');
+    }
+    if (this.movesElement) {
+      this.movesElement.textContent = this.stats.moves.toLocaleString('fr-FR');
+    }
+    if (this.optionStatusElement) {
+      if (this.stats.lastCombo > 0) {
+        this.optionStatusElement.textContent = `Dernier combo : ${this.stats.lastCombo.toLocaleString('fr-FR')}`;
+      } else {
+        this.optionStatusElement.textContent = '';
+      }
+    }
+  }
+
+  updateMessage(message) {
+    if (this.messageElement) {
+      this.messageElement.textContent = message || '';
+    }
+  }
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+}
+
+window.MetauxMatch3Game = MetauxMatch3Game;
+
+let metauxGame = null;
+
+function initMetauxGame() {
+  if (metauxGame || typeof MetauxMatch3Game !== 'function') {
+    return;
+  }
+  if (!elements || !elements.metauxBoard) {
+    return;
+  }
+  metauxGame = new MetauxMatch3Game({
+    boardElement: elements.metauxBoard,
+    lastComboElement: elements.metauxLastComboValue,
+    bestComboElement: elements.metauxBestComboValue,
+    totalTilesElement: elements.metauxTotalTilesValue,
+    reshufflesElement: elements.metauxReshufflesValue,
+    movesElement: elements.metauxMovesValue,
+    messageElement: elements.metauxMessage,
+    optionStatusElement: elements.metauxOptionStatus
+  });
+  metauxGame.initialize();
+}
+
+function getMetauxGame() {
+  return metauxGame;
+}
+
+window.initMetauxGame = initMetauxGame;
+window.getMetauxGame = getMetauxGame;

--- a/styles/main.css
+++ b/styles/main.css
@@ -4192,3 +4192,288 @@ body.theme-neon .devkit-panel__footer kbd {
     justify-content: center;
   }
 }
+
+.page--metaux {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
+  padding: clamp(1.2rem, 3vw, 2.6rem) clamp(1rem, 3.5vw, 3rem);
+}
+
+.metaux-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1rem, 2vw, 1.8rem);
+  flex-wrap: wrap;
+}
+
+.metaux-header__brand {
+  min-width: max-content;
+}
+
+.metaux-header__stats {
+  display: flex;
+  gap: clamp(0.6rem, 1.5vw, 1.2rem);
+  flex-wrap: wrap;
+}
+
+.metaux-stat {
+  padding: 0.6rem 1rem;
+  border-radius: 16px;
+  background: linear-gradient(160deg, rgba(18, 22, 42, 0.9), rgba(8, 10, 22, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    0 14px 28px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 0 32px rgba(255, 255, 255, 0.04);
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+}
+
+.metaux-stat__label {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.metaux-stat__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.metaux-content {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 1200px) {
+  .metaux-content {
+    grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
+    align-items: start;
+  }
+}
+
+.metaux-board-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.metaux-board {
+  --board-bg: linear-gradient(160deg, rgba(14, 18, 34, 0.9), rgba(8, 10, 22, 0.78));
+  display: grid;
+  grid-template-columns: repeat(32, minmax(0, 1fr));
+  gap: clamp(0.28rem, 0.6vw, 0.48rem);
+  width: min(96vw, 1320px);
+  padding: clamp(0.8rem, 2vw, 1.4rem);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: var(--board-bg);
+  box-shadow:
+    0 24px 48px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.1),
+    inset 0 0 48px rgba(255, 255, 255, 0.05);
+  position: relative;
+  overflow: hidden;
+}
+
+.metaux-board::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+.metaux-tile {
+  --tile-color: rgba(255, 255, 255, 0.55);
+  position: relative;
+  border-radius: 12px;
+  background: linear-gradient(155deg, rgba(20, 24, 42, 0.92), rgba(10, 12, 28, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow:
+    0 14px 26px rgba(0, 0, 0, 0.32),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 26px rgba(255, 255, 255, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #f8f9ff;
+  font-family: 'Orbitron', 'Inter', sans-serif;
+  font-size: clamp(0.44rem, 0.9vw, 0.7rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: grab;
+  touch-action: none;
+  transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease, opacity 0.18s ease;
+}
+
+.metaux-tile::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+  pointer-events: none;
+}
+
+.metaux-tile::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(150deg, var(--tile-color), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.metaux-tile span {
+  position: relative;
+  z-index: 1;
+}
+
+.metaux-tile.is-selected,
+.metaux-tile.is-target {
+  transform: translateY(-3px) scale(1.04);
+  box-shadow:
+    0 20px 36px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.12),
+    0 0 42px var(--tile-color);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+
+.metaux-tile.is-target {
+  cursor: grabbing;
+}
+
+.metaux-tile.is-clearing {
+  opacity: 0;
+  transform: scale(0.88);
+}
+
+.metaux-tile.is-empty {
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: none;
+  border-color: transparent;
+}
+
+.metaux-tile--bronze {
+  --tile-color: rgba(199, 126, 54, 0.72);
+}
+
+.metaux-tile--argent {
+  --tile-color: rgba(173, 190, 202, 0.78);
+}
+
+.metaux-tile--or {
+  --tile-color: rgba(245, 204, 79, 0.82);
+}
+
+.metaux-tile--platine {
+  --tile-color: rgba(166, 211, 227, 0.82);
+}
+
+.metaux-tile--diamant {
+  --tile-color: rgba(130, 217, 255, 0.88);
+}
+
+.metaux-message {
+  margin: 0;
+  min-height: 1.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  text-align: center;
+}
+
+.metaux-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: clamp(1rem, 2.6vw, 1.8rem);
+  border-radius: 24px;
+  background: linear-gradient(170deg, rgba(16, 19, 34, 0.92), rgba(8, 10, 22, 0.75));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    0 20px 38px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 0 36px rgba(255, 255, 255, 0.04);
+}
+
+.metaux-sidebar__title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.4vw, 1.4rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.metaux-sidebar__intro {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.5;
+}
+
+.metaux-sidebar__stats {
+  margin: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.metaux-sidebar__stat {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.metaux-sidebar__stat dt {
+  margin: 0;
+}
+
+.metaux-sidebar__stat dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.metaux-reshuffle-button {
+  align-self: flex-start;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.05));
+  color: #f8f9ff;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.metaux-reshuffle-button:hover,
+.metaux-reshuffle-button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.32);
+  border-color: rgba(255, 255, 255, 0.38);
+  outline: none;
+}
+
+.metaux-reshuffle-button:active {
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- add the Métaux mini-game page and expose it from the options menu
- implement a standalone match-3 engine with gravity, cascades, and shuffling safeguards
- style the board and HUD with visuals inspired by the gacha result cards

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7aa04cb08832e8b649a74ddfe7ce9