### PR TITLE
Refine Metaux minigame layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,6 +376,14 @@
     </section>
 
     <section id="metaux" class="page page--metaux" aria-label="Métaux" hidden>
+      <button
+        class="metaux-exit-button"
+        id="metauxExitButton"
+        type="button"
+        aria-label="Quitter le mini-jeu Métaux"
+      >
+        ×
+      </button>
       <header class="metaux-header" aria-label="Navigation du jeu Métaux">
         <button class="metaux-header__brand brand brand-button" id="metauxReturnButton" type="button">
           Métaux
@@ -483,7 +491,6 @@
           </p>
           <div class="option-row">
             <button type="button" id="metauxOpenButton" class="primary">Lancer Métaux</button>
-            <span class="option-note" id="metauxOptionStatus" role="status"></span>
           </div>
         </div>
         <div class="option-card" id="bigBangOptionCard" hidden>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1551,7 +1551,7 @@ const elements = {
   arcadeScoreValue: document.getElementById('arcadeScoreValue'),
   arcadeComboMessage: document.getElementById('arcadeComboMessage'),
   metauxOpenButton: document.getElementById('metauxOpenButton'),
-  metauxOptionStatus: document.getElementById('metauxOptionStatus'),
+  metauxExitButton: document.getElementById('metauxExitButton'),
   metauxReturnButton: document.getElementById('metauxReturnButton'),
   metauxBoard: document.getElementById('metauxBoard'),
   metauxLastComboValue: document.getElementById('metauxLastComboValue'),
@@ -4411,6 +4411,12 @@ elements.navButtons.forEach(btn => {
 if (elements.metauxOpenButton) {
   elements.metauxOpenButton.addEventListener('click', () => {
     showPage('metaux');
+  });
+}
+
+if (elements.metauxExitButton) {
+  elements.metauxExitButton.addEventListener('click', () => {
+    showPage('game');
   });
 }
 

--- a/scripts/modules/metaux-match3.js
+++ b/scripts/modules/metaux-match3.js
@@ -62,7 +62,6 @@ class MetauxMatch3Game {
     this.reshufflesElement = options.reshufflesElement || null;
     this.movesElement = options.movesElement || null;
     this.messageElement = options.messageElement || null;
-    this.optionStatusElement = options.optionStatusElement || null;
     this.board = Array.from({ length: METAUX_ROWS }, () => Array(METAUX_COLS).fill(null));
     this.tiles = Array.from({ length: METAUX_ROWS }, () => Array(METAUX_COLS).fill(null));
     this.initialized = false;
@@ -111,6 +110,7 @@ class MetauxMatch3Game {
       return;
     }
     this.boardElement.style.setProperty('--metaux-cols', METAUX_COLS);
+    this.boardElement.style.setProperty('--metaux-rows', METAUX_ROWS);
     this.boardElement.style.gridTemplateColumns = `repeat(${METAUX_COLS}, minmax(0, 1fr))`;
     this.boardElement.dataset.rows = String(METAUX_ROWS);
     this.boardElement.dataset.cols = String(METAUX_COLS);
@@ -645,13 +645,6 @@ class MetauxMatch3Game {
     if (this.movesElement) {
       this.movesElement.textContent = this.stats.moves.toLocaleString('fr-FR');
     }
-    if (this.optionStatusElement) {
-      if (this.stats.lastCombo > 0) {
-        this.optionStatusElement.textContent = `Dernier combo : ${this.stats.lastCombo.toLocaleString('fr-FR')}`;
-      } else {
-        this.optionStatusElement.textContent = '';
-      }
-    }
   }
 
   updateMessage(message) {
@@ -688,8 +681,7 @@ function initMetauxGame() {
     totalTilesElement: elements.metauxTotalTilesValue,
     reshufflesElement: elements.metauxReshufflesValue,
     movesElement: elements.metauxMovesValue,
-    messageElement: elements.metauxMessage,
-    optionStatusElement: elements.metauxOptionStatus
+    messageElement: elements.metauxMessage
   });
   metauxGame.initialize();
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -4194,10 +4194,49 @@ body.theme-neon .devkit-panel__footer kbd {
 }
 
 .page--metaux {
+  --metaux-vertical-space: clamp(3.5rem, 18vh, 12rem);
   display: flex;
   flex-direction: column;
   gap: clamp(1.5rem, 3vw, 2.4rem);
   padding: clamp(1.2rem, 3vw, 2.6rem) clamp(1rem, 3.5vw, 3rem);
+  position: relative;
+  min-height: 100vh;
+}
+
+.metaux-exit-button {
+  position: absolute;
+  top: clamp(0.8rem, 2vw, 1.6rem);
+  right: clamp(0.8rem, 2vw, 1.6rem);
+  width: clamp(2.25rem, 4vw, 2.75rem);
+  height: clamp(2.25rem, 4vw, 2.75rem);
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: linear-gradient(160deg, rgba(18, 22, 42, 0.88), rgba(8, 10, 22, 0.72));
+  color: rgba(255, 255, 255, 0.85);
+  font-size: clamp(1.2rem, 2vw, 1.4rem);
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow:
+    0 12px 24px rgba(0, 0, 0, 0.32),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  z-index: 4;
+}
+
+.metaux-exit-button:hover,
+.metaux-exit-button:focus {
+  transform: scale(1.05);
+  border-color: rgba(255, 255, 255, 0.45);
+  box-shadow:
+    0 14px 26px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.14);
+}
+
+.metaux-exit-button:active {
+  transform: scale(0.94);
 }
 
 .metaux-header {
@@ -4250,6 +4289,7 @@ body.theme-neon .devkit-panel__footer kbd {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
   grid-template-columns: minmax(0, 1fr);
+  justify-items: center;
 }
 
 @media (min-width: 1200px) {
@@ -4264,15 +4304,21 @@ body.theme-neon .devkit-panel__footer kbd {
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  width: min(100%, 1280px);
 }
 
 .metaux-board {
   --board-bg: linear-gradient(160deg, rgba(14, 18, 34, 0.9), rgba(8, 10, 22, 0.78));
   display: grid;
   grid-template-columns: repeat(var(--metaux-cols, 16), minmax(0, 1fr));
-  gap: clamp(0.28rem, 0.6vw, 0.48rem);
-  width: min(96vw, 1320px);
-  padding: clamp(0.8rem, 2vw, 1.4rem);
+  gap: clamp(0.18rem, 0.45vw, 0.34rem);
+  width: min(
+    90vw,
+    1280px,
+    calc((100vh - var(--metaux-vertical-space)) * var(--metaux-cols, 16) / var(--metaux-rows, 9))
+  );
+  max-height: calc(100vh - var(--metaux-vertical-space));
+  padding: clamp(0.6rem, 1.6vw, 1.1rem);
   border-radius: 28px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: var(--board-bg);
@@ -4282,6 +4328,7 @@ body.theme-neon .devkit-panel__footer kbd {
     inset 0 0 48px rgba(255, 255, 255, 0.05);
   position: relative;
   overflow: hidden;
+  margin: 0 auto;
 }
 
 .metaux-board::before {
@@ -4296,7 +4343,7 @@ body.theme-neon .devkit-panel__footer kbd {
 .metaux-tile {
   --tile-color: rgba(255, 255, 255, 0.55);
   position: relative;
-  border-radius: 12px;
+  border-radius: 10px;
   background: linear-gradient(155deg, rgba(20, 24, 42, 0.92), rgba(10, 12, 28, 0.7));
   border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow:
@@ -4308,7 +4355,7 @@ body.theme-neon .devkit-panel__footer kbd {
   justify-content: center;
   color: #f8f9ff;
   font-family: 'Orbitron', 'Inter', sans-serif;
-  font-size: clamp(0.44rem, 0.9vw, 0.7rem);
+  font-size: clamp(0.38rem, 0.8vw, 0.62rem);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add a compact exit button to leave the Métaux match-3 and jump back to the Atom2Univers game screen
- resize and recenter the Métaux grid so the full board fits within a 16:9 viewport with slightly smaller tiles
- remove the lingering options status text so Métaux HUD elements no longer appear on unrelated pages

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7b3809fb0832e8fbb79f85cdcba58