### PR TITLE
Fix metaux sidebar showing on all pages

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -4195,12 +4195,16 @@ body.theme-neon .devkit-panel__footer kbd {
 
 .page--metaux {
   --metaux-vertical-space: clamp(3.5rem, 18vh, 12rem);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2.4rem);
+  display: none;
   padding: clamp(1.2rem, 3vw, 2.6rem) clamp(1rem, 3.5vw, 3rem);
   position: relative;
   min-height: 100vh;
+}
+
+.page--metaux.active {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
 }
 
 .metaux-exit-button {


### PR DESCRIPTION
## Summary
- ensure the Métaux match-3 layout stays hidden until activated by moving its flex layout styles to the active state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b88ea560832ebf9c6698480be79e