### PR TITLE
Strip match-3 HUD elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,49 +384,10 @@
       >
         ×
       </button>
-      <header class="metaux-header" aria-label="Navigation du jeu Métaux">
-        <button class="metaux-header__brand brand brand-button" id="metauxReturnButton" type="button">
-          Métaux
-        </button>
-        <div class="metaux-header__stats" role="status" aria-live="polite">
-          <div class="metaux-stat">
-            <span class="metaux-stat__label">Dernier combo</span>
-            <span class="metaux-stat__value" id="metauxLastComboValue">0</span>
-          </div>
-          <div class="metaux-stat">
-            <span class="metaux-stat__label">Meilleur combo</span>
-            <span class="metaux-stat__value" id="metauxBestComboValue">0</span>
-          </div>
-          <div class="metaux-stat">
-            <span class="metaux-stat__label">Coups joués</span>
-            <span class="metaux-stat__value" id="metauxMovesValue">0</span>
-          </div>
-        </div>
-      </header>
       <div class="metaux-content">
         <div class="metaux-board-wrapper">
           <div class="metaux-board" id="metauxBoard" role="grid" aria-label="Grille du mini-jeu Métaux"></div>
-          <p class="metaux-message" id="metauxMessage" role="status" aria-live="polite"></p>
         </div>
-        <aside class="metaux-sidebar" aria-label="Suivi des métaux">
-          <h3 class="metaux-sidebar__title">Forge quantique</h3>
-          <p class="metaux-sidebar__intro">
-            Alignez au moins trois lingots identiques pour les raffiner et déclencher des réactions en cascade.
-          </p>
-          <dl class="metaux-sidebar__stats">
-            <div class="metaux-sidebar__stat">
-              <dt>Total de tuiles fondues</dt>
-              <dd id="metauxTotalTilesValue">0</dd>
-            </div>
-            <div class="metaux-sidebar__stat">
-              <dt>Re-mélanges</dt>
-              <dd id="metauxReshufflesValue">0</dd>
-            </div>
-          </dl>
-          <button type="button" class="metaux-reshuffle-button" id="metauxReshuffleButton">
-            Re-mélanger
-          </button>
-        </aside>
       </div>
     </section>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -4195,12 +4195,16 @@ body.theme-neon .devkit-panel__footer kbd {
 
 .page--metaux {
   --metaux-vertical-space: clamp(3.5rem, 18vh, 12rem);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2.4rem);
+  display: none;
   padding: clamp(1.2rem, 3vw, 2.6rem) clamp(1rem, 3.5vw, 3rem);
   position: relative;
   min-height: 100vh;
+}
+
+.page--metaux.active {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
 }
 
 .metaux-exit-button {
@@ -4290,13 +4294,6 @@ body.theme-neon .devkit-panel__footer kbd {
   gap: clamp(1.5rem, 3vw, 2.5rem);
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
-}
-
-@media (min-width: 1200px) {
-  .metaux-content {
-    grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
-    align-items: start;
-  }
 }
 
 .metaux-board-wrapper {


### PR DESCRIPTION
## Summary
- ensure the Métaux match-3 layout stays hidden until activated by moving its flex layout styles to the active state
- remove the Métaux HUD, stats, and sidebar markup so the match-3 page shows only the grid and close button
- simplify the match-3 layout styling so the board stays centered without the sidebar column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b88ea560832ebf9c6698480be79e