### PR TITLE
Add configurable pop animation and refill delay to Métaux mini-game

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -648,13 +648,21 @@ const GAME_CONFIG = {
    * Réglages du mini-jeu Métaux.
    * - rows / cols : dimensions de la grille.
    * - clearDelayMs : délai avant la disparition visuelle d'un alignement.
+   * - refillDelayMs : délai avant la réapparition de nouvelles cases.
+   * - popEffect : animation lors de la disparition, paramétrable.
    * - maxShuffleAttempts : nombre maximal de tentatives de redistribution.
    * - tileTypes : définition des métaux disponibles (identifiant, libellé, couleur).
    */
   metaux: {
     rows: 8,
     cols: 16,
-    clearDelayMs: 200,
+    clearDelayMs: 220,
+    refillDelayMs: 120,
+    popEffect: {
+      durationMs: 220,
+      scale: 1.18,
+      glowOpacity: 0.8
+    },
     maxShuffleAttempts: 120,
     tileTypes: [
       { id: 'bronze', label: 'Cu', color: '#C77E36' },

--- a/styles/main.css
+++ b/styles/main.css
@@ -4306,6 +4306,9 @@ body.theme-neon .devkit-panel__footer kbd {
 
 .metaux-board {
   --board-bg: linear-gradient(160deg, rgba(14, 18, 34, 0.9), rgba(8, 10, 22, 0.78));
+  --metaux-pop-duration: 220ms;
+  --metaux-pop-scale: 1.18;
+  --metaux-pop-glow-opacity: 0.8;
   display: grid;
   grid-template-columns: repeat(var(--metaux-cols, 16), minmax(0, 1fr));
   gap: clamp(0.18rem, 0.45vw, 0.34rem);
@@ -4335,6 +4338,48 @@ body.theme-neon .devkit-panel__footer kbd {
   border-radius: inherit;
   background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 60%);
   pointer-events: none;
+}
+
+@keyframes metaux-tile-pop {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+    box-shadow:
+      0 14px 26px rgba(0, 0, 0, 0.32),
+      0 0 0 1px rgba(255, 255, 255, 0.08),
+      0 0 26px rgba(255, 255, 255, 0.12);
+  }
+  60% {
+    transform: scale(var(--metaux-pop-scale, 1.18));
+    opacity: 1;
+    box-shadow:
+      0 20px 40px rgba(0, 0, 0, 0.4),
+      0 0 0 1px rgba(255, 255, 255, 0.2),
+      0 0 48px var(--tile-color);
+  }
+  100% {
+    transform: scale(0.4);
+    opacity: 0;
+    box-shadow:
+      0 8px 18px rgba(0, 0, 0, 0.3),
+      0 0 0 1px rgba(255, 255, 255, 0),
+      0 0 36px rgba(255, 255, 255, 0);
+  }
+}
+
+@keyframes metaux-tile-pop-glow {
+  0% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+  50% {
+    opacity: var(--metaux-pop-glow-opacity, 0.8);
+    transform: scale(calc(var(--metaux-pop-scale, 1.18) * 1.1));
+  }
+  100% {
+    opacity: 0;
+    transform: scale(calc(var(--metaux-pop-scale, 1.18) * 1.35));
+  }
 }
 
 .metaux-tile {
@@ -4404,8 +4449,26 @@ body.theme-neon .devkit-panel__footer kbd {
 }
 
 .metaux-tile.is-clearing {
-  opacity: 0;
-  transform: scale(0.88);
+  animation: metaux-tile-pop var(--metaux-pop-duration, 220ms) cubic-bezier(0.3, 0.8, 0.4, 1) forwards;
+  transition: none;
+}
+
+.metaux-tile.is-clearing::after {
+  animation: metaux-tile-pop-glow var(--metaux-pop-duration, 220ms) ease-out forwards;
+  opacity: var(--metaux-pop-glow-opacity, 0.8);
+}
+
+.metaux-tile.is-clearing span {
+  animation: metaux-tile-fade-out var(--metaux-pop-duration, 220ms) ease forwards;
+}
+
+@keyframes metaux-tile-fade-out {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 .metaux-tile.is-empty {


### PR DESCRIPTION
## Summary
- add configuration hooks for the Métaux mini-jeu to control pop animation and refill timing
- animate clearing tiles with a color-matched pop effect and delay new tiles so the effect remains visible
- update board setup to expose animation variables to CSS

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c172c62c832e8e90e42f855d0d90