### PR TITLE
Hide status bar during Metaux minigame

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -187,6 +187,10 @@ body.theme-neon .brand--portal-ready {
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+body.view-metaux .status-bar {
+  display: none;
+}
+
 .status-item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- hide the global status bar when the Metaux mini-game is active to remove the APS/APC display during play

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7cc2de258832e81030c3a3871b9ff