### PR TITLE
Rework APS crit bonus handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,32 +55,24 @@
         <span class="status-value status-value--main" id="statusAtoms">0</span>
       </div>
       <div class="status-side status-side--right">
+        <div class="status-item status-item--crit status-item--crit-aps" aria-live="polite">
+          <div
+            class="status-crit-display status-crit-display--aps"
+            id="statusApsCrit"
+            role="status"
+            aria-atomic="true"
+            hidden
+          >
+            <span class="status-aps-crit-value status-aps-crit-value--chrono" id="statusApsCritChrono">0&nbsp;s</span>
+            <span class="status-aps-crit-separator" aria-hidden="true">·</span>
+            <span class="status-aps-crit-value status-aps-crit-value--multiplier" id="statusApsCritMultiplier">×1</span>
+          </div>
+        </div>
         <div class="status-item status-item--right">
           <span class="status-label">APS</span>
           <div class="status-value-group status-value-group--aps">
             <span class="status-value" id="statusAps">0</span>
             <span class="status-frenzy-indicator" id="statusApsFrenzy" hidden></span>
-          </div>
-        </div>
-        <div class="status-item status-item--crit status-item--crit-aps" aria-live="polite">
-          <div
-            class="status-crit-display status-crit-display--aps is-active"
-            id="statusApsCrit"
-            role="status"
-            aria-atomic="true"
-          >
-            <div class="status-aps-crit-row">
-              <span class="status-aps-crit-label">Chrono</span>
-              <span class="status-aps-crit-value" id="statusApsCritChrono">0&nbsp;s</span>
-            </div>
-            <div class="status-aps-crit-row">
-              <span class="status-aps-crit-label">Multi</span>
-              <span class="status-aps-crit-value" id="statusApsCritMultiplier">×1</span>
-            </div>
-            <div class="status-aps-crit-row">
-              <span class="status-aps-crit-label">APS</span>
-              <span class="status-aps-crit-value" id="statusApsCritTotal">0</span>
-            </div>
           </div>
         </div>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -254,50 +254,52 @@ body.view-metaux .status-bar {
 }
 
 .status-item--crit-aps {
-  align-items: stretch;
+  align-items: center;
   justify-self: flex-end;
 }
 
 .status-crit-display--aps {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.2rem;
-  padding: clamp(0.28rem, 0.6vw, 0.42rem) clamp(0.6rem, 1.2vw, 0.95rem);
+  align-items: center;
+  gap: clamp(0.2rem, 0.45vw, 0.35rem);
+  padding: clamp(0.16rem, 0.45vw, 0.3rem) clamp(0.42rem, 0.9vw, 0.6rem);
   opacity: 1;
   transform: none;
-  transition: box-shadow 0.32s ease, transform 0.32s ease;
-  white-space: normal;
+  transition: box-shadow 0.28s ease, transform 0.28s ease;
+  white-space: nowrap;
 }
 
 .status-crit-display--aps::before {
-  inset: -45% -45% auto -45%;
-  opacity: 0.95;
+  inset: -28% -36% auto -36%;
+  opacity: 0.82;
 }
 
 .status-crit-display--aps.is-pulsing {
-  transform: translateY(0) scale(1.03);
-  box-shadow: 0 0.55rem 1.6rem rgba(255, 160, 60, 0.32);
-}
-
-.status-aps-crit-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.status-aps-crit-label {
-  font-size: 0.68em;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  opacity: 0.8;
+  transform: translateY(0) scale(1.05);
+  box-shadow: 0 0.45rem 1.2rem rgba(255, 160, 60, 0.28);
 }
 
 .status-aps-crit-value {
-  font-size: 0.92em;
+  font-size: clamp(0.58rem, 0.9vw, 0.75rem);
   font-weight: 600;
   min-width: 0;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.1rem;
+}
+
+.status-aps-crit-value--chrono {
+  letter-spacing: 0.04em;
+}
+
+.status-aps-crit-value--multiplier {
+  font-variant-numeric: tabular-nums;
+}
+
+.status-aps-crit-separator {
+  font-size: clamp(0.58rem, 0.9vw, 0.72rem);
+  opacity: 0.75;
+  transform: translateY(-0.02rem);
 }
 
 .status-aps-crit-value--pulse {


### PR DESCRIPTION
## Summary
- replace the APS crit state with individual timed effects so bonuses expire when their timer ends
- adjust Metaux session rewards to add multipliers without extending existing timers and update serialization
- restyle and reposition the APS crit banner to a compact timer × multiplier pill that hides when inactive

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d7e6833698832ebe1b1df337414bb3