### PR TITLE
Move additional presentation data into app data module

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,6 +707,7 @@
   <script src="scripts/modules/info.js"></script>
   <script src="scripts/modules/sound-designer.js"></script>
   <script src="scripts/modules/metaux-match3.js"></script>
+  <script src="scripts/modules/app-data.js"></script>
   <script src="scripts/app.js"></script>
 </body>
 </html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,257 +1,32 @@
-const DEFAULT_ATOM_SCALE_TROPHY_DATA = [
-  {
-    id: 'scaleHumanCell',
-    name: 'Échelle : cellule humaine',
-    targetText: '10^14',
-    flavor: 'l’équivalent d’une cellule humaine « moyenne »',
-    amount: { type: 'layer0', mantissa: 1, exponent: 14 }
-  },
-  {
-    id: 'scaleSandGrain',
-    name: 'Échelle : grain de sable',
-    targetText: '10^19',
-    flavor: 'la masse d’un grain de sable (~1 mm)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 19 }
-  },
-  {
-    id: 'scaleAnt',
-    name: 'Échelle : fourmi',
-    targetText: '10^20',
-    flavor: 'comparable à une fourmi (~5 mg)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 20 }
-  },
-  {
-    id: 'scaleWaterDrop',
-    name: 'Échelle : goutte d’eau',
-    targetText: '5 × 10^21',
-    flavor: 'la quantité d’atomes contenue dans une goutte d’eau de 0,05 mL',
-    amount: { type: 'layer0', mantissa: 5, exponent: 21 }
-  },
-  {
-    id: 'scalePaperclip',
-    name: 'Échelle : trombone',
-    targetText: '10^22',
-    flavor: 'l’équivalent d’un trombone en fer (~1 g)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 22 }
-  },
-  {
-    id: 'scaleCoin',
-    name: 'Échelle : pièce',
-    targetText: '10^23',
-    flavor: 'la masse atomique d’une pièce de monnaie (~7,5 g)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 23 }
-  },
-  {
-    id: 'scaleApple',
-    name: 'Échelle : pomme',
-    targetText: '10^25',
-    flavor: 'la masse atomique d’une pomme (~100 g)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 25 }
-  },
-  {
-    id: 'scaleSmartphone',
-    name: 'Échelle : smartphone',
-    targetText: '3 × 10^25',
-    flavor: 'autant qu’un smartphone moderne (~180 g)',
-    amount: { type: 'layer0', mantissa: 3, exponent: 25 }
-  },
-  {
-    id: 'scaleWaterLitre',
-    name: 'Échelle : litre d’eau',
-    targetText: '10^26',
-    flavor: 'l’équivalent d’un litre d’eau (~300 g)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 26 }
-  },
-  {
-    id: 'scaleHuman',
-    name: 'Échelle : être humain',
-    targetText: '7 × 10^27',
-    flavor: 'comparable à un humain de 70 kg',
-    amount: { type: 'layer0', mantissa: 7, exponent: 27 }
-  },
-  {
-    id: 'scalePiano',
-    name: 'Échelle : piano',
-    targetText: '10^29',
-    flavor: 'équivaut à un piano (~450 kg)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 29 }
-  },
-  {
-    id: 'scaleCar',
-    name: 'Échelle : voiture compacte',
-    targetText: '10^30',
-    flavor: 'autant qu’une voiture compacte (~1,3 t)',
-    amount: { type: 'layer0', mantissa: 1, exponent: 30 }
-  },
-  {
-    id: 'scaleElephant',
-    name: 'Échelle : éléphant',
-    targetText: '3 × 10^31',
-    flavor: 'équivaut à un éléphant (~6 t)',
-    amount: { type: 'layer0', mantissa: 3, exponent: 31 }
-  },
-  {
-    id: 'scaleBoeing747',
-    name: 'Échelle : Boeing 747',
-    targetText: '10^33',
-    flavor: 'autant qu’un Boeing 747',
-    amount: { type: 'layer0', mantissa: 1, exponent: 33 }
-  },
-  {
-    id: 'scalePyramid',
-    name: 'Échelle : pyramide de Khéops',
-    targetText: '2 × 10^35',
-    flavor: 'la masse d’atomes de la grande pyramide de Khéops',
-    amount: { type: 'layer0', mantissa: 2, exponent: 35 }
-  },
-  {
-    id: 'scaleAtmosphere',
-    name: 'Échelle : atmosphère terrestre',
-    targetText: '2 × 10^44',
-    flavor: 'équivaut à l’atmosphère terrestre complète',
-    amount: { type: 'layer0', mantissa: 2, exponent: 44 }
-  },
-  {
-    id: 'scaleOceans',
-    name: 'Échelle : océans terrestres',
-    targetText: '10^47',
-    flavor: 'autant que tous les océans de la Terre',
-    amount: { type: 'layer0', mantissa: 1, exponent: 47 }
-  },
-  {
-    id: 'scaleEarth',
-    name: 'Échelle : Terre',
-    targetText: '10^50',
-    flavor: 'égale la masse atomique de la planète Terre',
-    amount: { type: 'layer0', mantissa: 1, exponent: 50 }
-  },
-  {
-    id: 'scaleSun',
-    name: 'Échelle : Soleil',
-    targetText: '10^57',
-    flavor: 'équivaut au Soleil',
-    amount: { type: 'layer0', mantissa: 1, exponent: 57 }
-  },
-  {
-    id: 'scaleMilkyWay',
-    name: 'Échelle : Voie lactée',
-    targetText: '10^69',
-    flavor: 'comparable à la Voie lactée entière',
-    amount: { type: 'layer0', mantissa: 1, exponent: 69 }
-  },
-  {
-    id: 'scaleLocalGroup',
-    name: 'Échelle : Groupe local',
-    targetText: '10^71',
-    flavor: 'autant que le Groupe local de galaxies',
-    amount: { type: 'layer0', mantissa: 1, exponent: 71 }
-  },
-  {
-    id: 'scaleVirgoCluster',
-    name: 'Échelle : superamas de la Vierge',
-    targetText: '10^74',
-    flavor: 'équivaut au superamas de la Vierge',
-    amount: { type: 'layer0', mantissa: 1, exponent: 74 }
-  },
-  {
-    id: 'scaleObservableUniverse',
-    name: 'Échelle : univers observable',
-    targetText: '10^80',
-    flavor: 'atteignez le total estimé d’atomes de l’univers observable',
-    amount: { type: 'layer0', mantissa: 1, exponent: 80 }
-  }
-];
+const APP_DATA = typeof globalThis !== 'undefined' && globalThis.APP_DATA ? globalThis.APP_DATA : {};
 
-const ATOM_SCALE_TROPHY_DATA = Array.isArray(globalThis.ATOM_SCALE_TROPHY_DATA)
-  ? globalThis.ATOM_SCALE_TROPHY_DATA
-  : DEFAULT_ATOM_SCALE_TROPHY_DATA;
+const ATOM_SCALE_TROPHY_DATA = Array.isArray(APP_DATA.ATOM_SCALE_TROPHY_DATA)
+  ? APP_DATA.ATOM_SCALE_TROPHY_DATA
+  : [];
 
-function formatAtomScaleBonusValue(value) {
-  if (!Number.isFinite(value)) {
-    return '0';
-  }
-  const roundedInteger = Math.round(value);
-  if (Math.abs(value - roundedInteger) <= 1e-9) {
-    return roundedInteger.toLocaleString('fr-FR');
-  }
-  return value.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-}
+const FALLBACK_MILESTONES = Array.isArray(APP_DATA.FALLBACK_MILESTONES)
+  ? APP_DATA.FALLBACK_MILESTONES
+  : [];
 
-function createFallbackAtomScaleTrophies() {
-  const bonusPerTrophy = 2;
-  return ATOM_SCALE_TROPHY_DATA.map((entry, index) => {
-    const displayBonus = formatAtomScaleBonusValue(bonusPerTrophy);
-    const displayTotal = formatAtomScaleBonusValue(1 + bonusPerTrophy);
-    return {
-      id: entry.id,
-      name: entry.name,
-      description: `Atteignez ${entry.targetText} atomes cumulés, ${entry.flavor}.`,
-      condition: {
-        type: 'lifetimeAtoms',
-        amount: entry.amount
-      },
-      reward: {
-        trophyMultiplierAdd: bonusPerTrophy,
-        description: `Ajoute +${displayBonus} au Boost global sur la production manuelle et automatique (×${displayTotal} pour ce palier).`
-      },
-      order: index
-    };
-  });
-}
+const FALLBACK_TROPHIES = Array.isArray(APP_DATA.FALLBACK_TROPHIES)
+  ? APP_DATA.FALLBACK_TROPHIES
+  : [];
 
-const FALLBACK_MILESTONES = [
-  { amount: 100, text: 'Collectez 100 atomes pour débloquer la synthèse automatique.' },
-  { amount: 1_000, text: 'Atteignez 1 000 atomes pour améliorer vos gants quantiques.' },
-  { amount: 1_000_000, text: 'Atteignez 1 million d’atomes pour accéder aux surcadences.' },
-  { amount: { type: 'layer0', mantissa: 1, exponent: 8 }, text: 'Accumulez 10^8 atomes pour préparer la prochaine ère.' }
-];
+const MUSIC_SUPPORTED_EXTENSIONS = Array.isArray(APP_DATA.MUSIC_SUPPORTED_EXTENSIONS)
+  && APP_DATA.MUSIC_SUPPORTED_EXTENSIONS.length
+    ? [...APP_DATA.MUSIC_SUPPORTED_EXTENSIONS]
+    : Array.isArray(APP_DATA.DEFAULT_MUSIC_SUPPORTED_EXTENSIONS)
+      && APP_DATA.DEFAULT_MUSIC_SUPPORTED_EXTENSIONS.length
+      ? [...APP_DATA.DEFAULT_MUSIC_SUPPORTED_EXTENSIONS]
+      : ['mp3', 'ogg', 'wav', 'webm', 'm4a'];
 
-const FALLBACK_TROPHIES = [
-  ...createFallbackAtomScaleTrophies(),
-  {
-    id: 'millionAtoms',
-    name: 'Ruée vers le million',
-    description: 'Accumulez un total d’un million d’atomes synthétisés.',
-    condition: {
-      type: 'lifetimeAtoms',
-      amount: { type: 'number', value: 1_000_000 }
-    },
-    reward: {
-      trophyMultiplierAdd: 0.5,
-      description: 'Ajoute +0,5 au Boost global sur la production manuelle et automatique (×1,50 une fois ce succès débloqué).'
-    },
-    order: 1000
-  },
-  {
-    id: 'frenzyCollector',
-    name: 'Convergence frénétique',
-    description: 'Déclenchez 100 frénésies (APC et APS cumulés).',
-    condition: {
-      type: 'frenzyTotal',
-      amount: 100
-    },
-    reward: {
-      frenzyMaxStacks: 2,
-      description: 'Débloque la frénésie multiple : deux frénésies peuvent se cumuler.'
-    },
-    order: 1010
-  },
-  {
-    id: 'frenzyMaster',
-    name: 'Tempête tri-phasée',
-    description: 'Déclenchez 1 000 frénésies cumulées.',
-    condition: {
-      type: 'frenzyTotal',
-      amount: 1_000
-    },
-    reward: {
-      frenzyMaxStacks: 3,
-      multiplier: { global: 1.05 },
-      description: 'Active la triple frénésie et ajoute un bonus global ×1,05.'
-    },
-    order: 1020
-  }
-];
+const MUSIC_FALLBACK_TRACKS = Array.isArray(APP_DATA.MUSIC_FALLBACK_TRACKS)
+  && APP_DATA.MUSIC_FALLBACK_TRACKS.length
+    ? [...APP_DATA.MUSIC_FALLBACK_TRACKS]
+    : Array.isArray(APP_DATA.DEFAULT_MUSIC_FALLBACK_TRACKS)
+      && APP_DATA.DEFAULT_MUSIC_FALLBACK_TRACKS.length
+      ? [...APP_DATA.DEFAULT_MUSIC_FALLBACK_TRACKS]
+      : [];
 
 function createInitialStats() {
   const now = Date.now();
@@ -1913,15 +1688,8 @@ const soundEffects = (() => {
 
 const musicPlayer = (() => {
   const MUSIC_DIR = 'Assets/Music/';
-  const SUPPORTED_EXTENSIONS = ['mp3', 'ogg', 'wav', 'webm', 'm4a'];
-  const FALLBACK_TRACKS = [
-    'Piste1.mp3',
-    'Piste2.mp3',
-    'Piste3.mp3',
-    'Piste4.mp3',
-    'Piste5.mp3',
-    'Piste6.mp3'
-  ];
+  const SUPPORTED_EXTENSIONS = MUSIC_SUPPORTED_EXTENSIONS;
+  const FALLBACK_TRACKS = MUSIC_FALLBACK_TRACKS;
 
   if (typeof window === 'undefined' || typeof Audio === 'undefined') {
     const resolved = Promise.resolve([]);
@@ -3785,12 +3553,31 @@ function updateClickHistory(now = performance.now()) {
   targetClickStrength = Math.min(1, curved * 1.08);
 }
 
-const glowStops = [
-  { stop: 0, color: [248, 226, 158] },
-  { stop: 0.35, color: [255, 202, 112] },
-  { stop: 0.65, color: [255, 130, 54] },
-  { stop: 1, color: [255, 46, 18] }
-];
+const glowStops = (() => {
+  const source = Array.isArray(APP_DATA.GLOW_STOPS) && APP_DATA.GLOW_STOPS.length
+    ? APP_DATA.GLOW_STOPS
+    : Array.isArray(APP_DATA.DEFAULT_GLOW_STOPS) && APP_DATA.DEFAULT_GLOW_STOPS.length
+      ? APP_DATA.DEFAULT_GLOW_STOPS
+      : [];
+  if (!source.length) {
+    return [
+      { stop: 0, color: [255, 255, 255] }
+    ];
+  }
+  return source.map(entry => {
+    const stop = Number(entry?.stop);
+    const colorSource = Array.isArray(entry?.color) ? entry.color : [];
+    const color = [0, 0, 0];
+    for (let i = 0; i < 3; i += 1) {
+      const value = Number(colorSource[i]);
+      color[i] = Number.isFinite(value) ? value : 0;
+    }
+    return {
+      stop: Number.isFinite(stop) ? stop : 0,
+      color
+    };
+  }).sort((a, b) => a.stop - b.stop);
+})();
 
 function interpolateGlowColor(strength) {
   const clamped = Math.max(0, Math.min(1, strength));
@@ -4081,21 +3868,35 @@ function initStarfield() {
   elements.starfield.appendChild(fragment);
 }
 
-const CRIT_CONFETTI_COLORS = [
-  '#ff8ba7', '#ffd166', '#6fffe9', '#a5b4ff', '#ff9ff3',
-  '#70d6ff', '#fcd5ce', '#caffbf', '#bdb2ff', '#ffe066'
-];
+const CRIT_CONFETTI_COLORS = (() => {
+  const source = Array.isArray(APP_DATA.CRIT_CONFETTI_COLORS) && APP_DATA.CRIT_CONFETTI_COLORS.length
+    ? APP_DATA.CRIT_CONFETTI_COLORS
+    : Array.isArray(APP_DATA.DEFAULT_CRIT_CONFETTI_COLORS) && APP_DATA.DEFAULT_CRIT_CONFETTI_COLORS.length
+      ? APP_DATA.DEFAULT_CRIT_CONFETTI_COLORS
+      : [];
+  if (!source.length) {
+    return ['#ffffff'];
+  }
+  return source.map(value => String(value));
+})();
 
-const CRIT_CONFETTI_SHAPES = [
-  { className: 'crit-confetti--circle', widthFactor: 1, heightFactor: 1 },
-  { className: 'crit-confetti--oval', widthFactor: 1.4, heightFactor: 1 },
-  { className: 'crit-confetti--heart', widthFactor: 1.1, heightFactor: 1.1 },
-  { className: 'crit-confetti--star', widthFactor: 1.2, heightFactor: 1.2 },
-  { className: 'crit-confetti--square', widthFactor: 1, heightFactor: 1 },
-  { className: 'crit-confetti--triangle', widthFactor: 1.15, heightFactor: 1.3 },
-  { className: 'crit-confetti--rectangle', widthFactor: 1.8, heightFactor: 0.7 },
-  { className: 'crit-confetti--hexagon', widthFactor: 1.1, heightFactor: 1 }
-];
+const CRIT_CONFETTI_SHAPES = (() => {
+  const source = Array.isArray(APP_DATA.CRIT_CONFETTI_SHAPES) && APP_DATA.CRIT_CONFETTI_SHAPES.length
+    ? APP_DATA.CRIT_CONFETTI_SHAPES
+    : Array.isArray(APP_DATA.DEFAULT_CRIT_CONFETTI_SHAPES) && APP_DATA.DEFAULT_CRIT_CONFETTI_SHAPES.length
+      ? APP_DATA.DEFAULT_CRIT_CONFETTI_SHAPES
+      : [];
+  if (!source.length) {
+    return [{ className: 'crit-confetti--circle', widthFactor: 1, heightFactor: 1 }];
+  }
+  return source
+    .map(entry => ({
+      className: String(entry?.className ?? ''),
+      widthFactor: Number(entry?.widthFactor) || 1,
+      heightFactor: Number(entry?.heightFactor) || 1
+    }))
+    .filter(entry => entry.className);
+})();
 
 function ensureCritConfettiLayer() {
   if (elements.critConfettiLayer && elements.critConfettiLayer.isConnected) {

--- a/scripts/modules/app-data.js
+++ b/scripts/modules/app-data.js
@@ -1,0 +1,524 @@
+(function initAppData(global) {
+  const existingAppData = global.APP_DATA && typeof global.APP_DATA === 'object'
+    ? global.APP_DATA
+    : null;
+
+  const DEFAULT_ATOM_SCALE_TROPHY_DATA = [
+    {
+      id: 'scaleHumanCell',
+      name: 'Échelle : cellule humaine',
+      targetText: '10^14',
+      flavor: 'l’équivalent d’une cellule humaine « moyenne »',
+      amount: { type: 'layer0', mantissa: 1, exponent: 14 }
+    },
+    {
+      id: 'scaleSandGrain',
+      name: 'Échelle : grain de sable',
+      targetText: '10^19',
+      flavor: 'la masse d’un grain de sable (~1 mm)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 19 }
+    },
+    {
+      id: 'scaleAnt',
+      name: 'Échelle : fourmi',
+      targetText: '10^20',
+      flavor: 'comparable à une fourmi (~5 mg)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 20 }
+    },
+    {
+      id: 'scaleWaterDrop',
+      name: 'Échelle : goutte d’eau',
+      targetText: '5 × 10^21',
+      flavor: 'la quantité d’atomes contenue dans une goutte d’eau de 0,05 mL',
+      amount: { type: 'layer0', mantissa: 5, exponent: 21 }
+    },
+    {
+      id: 'scalePaperclip',
+      name: 'Échelle : trombone',
+      targetText: '10^22',
+      flavor: 'l’équivalent d’un trombone en fer (~1 g)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 22 }
+    },
+    {
+      id: 'scaleCoin',
+      name: 'Échelle : pièce',
+      targetText: '10^23',
+      flavor: 'la masse atomique d’une pièce de monnaie (~7,5 g)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 23 }
+    },
+    {
+      id: 'scaleApple',
+      name: 'Échelle : pomme',
+      targetText: '10^25',
+      flavor: 'la masse atomique d’une pomme (~100 g)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 25 }
+    },
+    {
+      id: 'scaleSmartphone',
+      name: 'Échelle : smartphone',
+      targetText: '3 × 10^25',
+      flavor: 'autant qu’un smartphone moderne (~180 g)',
+      amount: { type: 'layer0', mantissa: 3, exponent: 25 }
+    },
+    {
+      id: 'scaleWaterLitre',
+      name: 'Échelle : litre d’eau',
+      targetText: '10^26',
+      flavor: 'l’équivalent d’un litre d’eau (~300 g)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 26 }
+    },
+    {
+      id: 'scaleHuman',
+      name: 'Échelle : être humain',
+      targetText: '7 × 10^27',
+      flavor: 'comparable à un humain de 70 kg',
+      amount: { type: 'layer0', mantissa: 7, exponent: 27 }
+    },
+    {
+      id: 'scalePiano',
+      name: 'Échelle : piano',
+      targetText: '10^29',
+      flavor: 'équivaut à un piano (~450 kg)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 29 }
+    },
+    {
+      id: 'scaleCar',
+      name: 'Échelle : voiture compacte',
+      targetText: '10^30',
+      flavor: 'autant qu’une voiture compacte (~1,3 t)',
+      amount: { type: 'layer0', mantissa: 1, exponent: 30 }
+    },
+    {
+      id: 'scaleElephant',
+      name: 'Échelle : éléphant',
+      targetText: '3 × 10^31',
+      flavor: 'équivaut à un éléphant (~6 t)',
+      amount: { type: 'layer0', mantissa: 3, exponent: 31 }
+    },
+    {
+      id: 'scaleBoeing747',
+      name: 'Échelle : Boeing 747',
+      targetText: '10^33',
+      flavor: 'autant qu’un Boeing 747',
+      amount: { type: 'layer0', mantissa: 1, exponent: 33 }
+    },
+    {
+      id: 'scalePyramid',
+      name: 'Échelle : pyramide de Khéops',
+      targetText: '2 × 10^35',
+      flavor: 'la masse d’atomes de la grande pyramide de Khéops',
+      amount: { type: 'layer0', mantissa: 2, exponent: 35 }
+    },
+    {
+      id: 'scaleAtmosphere',
+      name: 'Échelle : atmosphère terrestre',
+      targetText: '2 × 10^44',
+      flavor: 'équivaut à l’atmosphère terrestre complète',
+      amount: { type: 'layer0', mantissa: 2, exponent: 44 }
+    },
+    {
+      id: 'scaleOceans',
+      name: 'Échelle : océans terrestres',
+      targetText: '10^47',
+      flavor: 'autant que tous les océans de la Terre',
+      amount: { type: 'layer0', mantissa: 1, exponent: 47 }
+    },
+    {
+      id: 'scaleEarth',
+      name: 'Échelle : Terre',
+      targetText: '10^50',
+      flavor: 'égale la masse atomique de la planète Terre',
+      amount: { type: 'layer0', mantissa: 1, exponent: 50 }
+    },
+    {
+      id: 'scaleSun',
+      name: 'Échelle : Soleil',
+      targetText: '10^57',
+      flavor: 'équivaut au Soleil',
+      amount: { type: 'layer0', mantissa: 1, exponent: 57 }
+    },
+    {
+      id: 'scaleMilkyWay',
+      name: 'Échelle : Voie lactée',
+      targetText: '10^69',
+      flavor: 'comparable à la Voie lactée entière',
+      amount: { type: 'layer0', mantissa: 1, exponent: 69 }
+    },
+    {
+      id: 'scaleLocalGroup',
+      name: 'Échelle : Groupe local',
+      targetText: '10^71',
+      flavor: 'autant que le Groupe local de galaxies',
+      amount: { type: 'layer0', mantissa: 1, exponent: 71 }
+    },
+    {
+      id: 'scaleVirgoCluster',
+      name: 'Échelle : superamas de la Vierge',
+      targetText: '10^74',
+      flavor: 'équivaut au superamas de la Vierge',
+      amount: { type: 'layer0', mantissa: 1, exponent: 74 }
+    },
+    {
+      id: 'scaleObservableUniverse',
+      name: 'Échelle : univers observable',
+      targetText: '10^80',
+      flavor: 'atteignez le total estimé d’atomes de l’univers observable',
+      amount: { type: 'layer0', mantissa: 1, exponent: 80 }
+    }
+  ];
+
+  const ATOM_SCALE_TROPHY_DATA = Array.isArray(global.ATOM_SCALE_TROPHY_DATA)
+    ? global.ATOM_SCALE_TROPHY_DATA
+    : DEFAULT_ATOM_SCALE_TROPHY_DATA;
+
+  function formatAtomScaleBonusValue(value) {
+    if (!Number.isFinite(value)) {
+      return '0';
+    }
+    const roundedInteger = Math.round(value);
+    if (Math.abs(value - roundedInteger) <= 1e-9) {
+      return roundedInteger.toLocaleString('fr-FR');
+    }
+    return value.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function createFallbackAtomScaleTrophies() {
+    const bonusPerTrophy = 2;
+    return ATOM_SCALE_TROPHY_DATA.map((entry, index) => {
+      const displayBonus = formatAtomScaleBonusValue(bonusPerTrophy);
+      const displayTotal = formatAtomScaleBonusValue(1 + bonusPerTrophy);
+      return {
+        id: entry.id,
+        name: entry.name,
+        description: `Atteignez ${entry.targetText} atomes cumulés, ${entry.flavor}.`,
+        condition: {
+          type: 'lifetimeAtoms',
+          amount: entry.amount
+        },
+        reward: {
+          trophyMultiplierAdd: bonusPerTrophy,
+          description: `Ajoute +${displayBonus} au Boost global sur la production manuelle et automatique (×${displayTotal} pour ce palier).`
+        },
+        order: index
+      };
+    });
+  }
+
+  const FALLBACK_MILESTONES = [
+    { amount: 100, text: 'Collectez 100 atomes pour débloquer la synthèse automatique.' },
+    { amount: 1_000, text: 'Atteignez 1 000 atomes pour améliorer vos gants quantiques.' },
+    { amount: 1_000_000, text: 'Atteignez 1 million d’atomes pour accéder aux surcadences.' },
+    { amount: { type: 'layer0', mantissa: 1, exponent: 8 }, text: 'Accumulez 10^8 atomes pour préparer la prochaine ère.' }
+  ];
+
+  const FALLBACK_TROPHIES = [
+    ...createFallbackAtomScaleTrophies(),
+    {
+      id: 'millionAtoms',
+      name: 'Ruée vers le million',
+      description: 'Accumulez un total d’un million d’atomes synthétisés.',
+      condition: {
+        type: 'lifetimeAtoms',
+        amount: { type: 'number', value: 1_000_000 }
+      },
+      reward: {
+        trophyMultiplierAdd: 0.5,
+        description: 'Ajoute +0,5 au Boost global sur la production manuelle et automatique (×1,50 une fois ce succès débloqué).'
+      },
+      order: 1000
+    },
+    {
+      id: 'frenzyCollector',
+      name: 'Convergence frénétique',
+      description: 'Déclenchez 100 frénésies (APC et APS cumulés).',
+      condition: {
+        type: 'frenzyTotal',
+        amount: 100
+      },
+      reward: {
+        frenzyMaxStacks: 2,
+        description: 'Débloque la frénésie multiple : deux frénésies peuvent se cumuler.'
+      },
+      order: 1010
+    },
+    {
+      id: 'frenzyMaster',
+      name: 'Tempête tri-phasée',
+      description: 'Déclenchez 1 000 frénésies cumulées.',
+      condition: {
+        type: 'frenzyTotal',
+        amount: 1_000
+      },
+      reward: {
+        frenzyMaxStacks: 3,
+        multiplier: { global: 1.05 },
+        description: 'Active la triple frénésie et ajoute un bonus global ×1,05.'
+      },
+      order: 1020
+    }
+  ];
+
+  const DEFAULT_MUSIC_SUPPORTED_EXTENSIONS = Object.freeze(['mp3', 'ogg', 'wav', 'webm', 'm4a']);
+
+  const DEFAULT_MUSIC_FALLBACK_TRACKS = Object.freeze([
+    'Piste1.mp3',
+    'Piste2.mp3',
+    'Piste3.mp3',
+    'Piste4.mp3',
+    'Piste5.mp3',
+    'Piste6.mp3'
+  ]);
+
+  function sanitizeMusicExtensions(raw) {
+    const candidates = Array.isArray(raw)
+      ? raw
+      : raw != null
+        ? [raw]
+        : [];
+    const seen = new Set();
+    const sanitized = [];
+    candidates.forEach(entry => {
+      let value = null;
+      if (typeof entry === 'string') {
+        value = entry;
+      } else if (entry && typeof entry === 'object') {
+        value = entry.extension ?? entry.ext ?? entry.value ?? null;
+      }
+      if (!value) {
+        return;
+      }
+      const normalized = String(value)
+        .trim()
+        .toLowerCase()
+        .replace(/^[.]+/, '');
+      if (!normalized || seen.has(normalized)) {
+        return;
+      }
+      seen.add(normalized);
+      sanitized.push(normalized);
+    });
+    if (!sanitized.length) {
+      return [...DEFAULT_MUSIC_SUPPORTED_EXTENSIONS];
+    }
+    return sanitized;
+  }
+
+  function sanitizeFallbackTracks(raw) {
+    const candidates = Array.isArray(raw)
+      ? raw
+      : raw != null
+        ? [raw]
+        : [];
+    const sanitized = [];
+    candidates.forEach(entry => {
+      let value = null;
+      if (typeof entry === 'string') {
+        value = entry;
+      } else if (entry && typeof entry === 'object') {
+        value = entry.path
+          ?? entry.src
+          ?? entry.url
+          ?? entry.file
+          ?? entry.filename
+          ?? entry.name
+          ?? null;
+      }
+      if (!value) {
+        return;
+      }
+      const normalized = String(value).trim();
+      if (!normalized) {
+        return;
+      }
+      sanitized.push(normalized);
+    });
+    if (!sanitized.length) {
+      return [...DEFAULT_MUSIC_FALLBACK_TRACKS];
+    }
+    return sanitized;
+  }
+
+  function parseRgbColor(value) {
+    if (Array.isArray(value)) {
+      const color = [];
+      for (let i = 0; i < 3; i += 1) {
+        const numeric = Number(value[i]);
+        if (!Number.isFinite(numeric)) {
+          return null;
+        }
+        color.push(Math.max(0, Math.min(255, Math.round(numeric))));
+      }
+      return color;
+    }
+    if (typeof value === 'string') {
+      let hex = value.trim();
+      if (!hex) {
+        return null;
+      }
+      if (hex.startsWith('#')) {
+        hex = hex.slice(1);
+      }
+      if (hex.length === 3) {
+        hex = hex
+          .split('')
+          .map(char => `${char}${char}`)
+          .join('');
+      }
+      if (hex.length !== 6 || /[^0-9a-f]/i.test(hex)) {
+        return null;
+      }
+      const color = [
+        parseInt(hex.slice(0, 2), 16),
+        parseInt(hex.slice(2, 4), 16),
+        parseInt(hex.slice(4, 6), 16)
+      ];
+      return color;
+    }
+    return null;
+  }
+
+  const DEFAULT_GLOW_STOPS = Object.freeze([
+    { stop: 0, color: [248, 226, 158] },
+    { stop: 0.35, color: [255, 202, 112] },
+    { stop: 0.65, color: [255, 130, 54] },
+    { stop: 1, color: [255, 46, 18] }
+  ]);
+
+  function sanitizeGlowStops(raw) {
+    const base = Array.isArray(raw) ? raw : [];
+    const sanitized = [];
+    base.forEach(entry => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const stopValue = Number(entry.stop ?? entry.position ?? entry.offset ?? entry.value);
+      if (!Number.isFinite(stopValue)) {
+        return;
+      }
+      const color = parseRgbColor(entry.color ?? entry.rgb ?? entry.hex ?? entry.value);
+      if (!color) {
+        return;
+      }
+      sanitized.push({
+        stop: Math.max(0, Math.min(1, stopValue)),
+        color
+      });
+    });
+    if (sanitized.length < 2) {
+      return DEFAULT_GLOW_STOPS.map(entry => ({ stop: entry.stop, color: [...entry.color] }));
+    }
+    sanitized.sort((a, b) => a.stop - b.stop);
+    return sanitized;
+  }
+
+  const DEFAULT_CRIT_CONFETTI_COLORS = Object.freeze([
+    '#ff8ba7', '#ffd166', '#6fffe9', '#a5b4ff', '#ff9ff3',
+    '#70d6ff', '#fcd5ce', '#caffbf', '#bdb2ff', '#ffe066'
+  ]);
+
+  function sanitizeConfettiColors(raw) {
+    const candidates = Array.isArray(raw) ? raw : [];
+    const seen = new Set();
+    const sanitized = [];
+    candidates.forEach(entry => {
+      const value = typeof entry === 'string'
+        ? entry
+        : (entry && typeof entry === 'object' ? entry.color ?? entry.value ?? null : null);
+      if (!value) {
+        return;
+      }
+      const normalized = String(value).trim();
+      if (!normalized || seen.has(normalized)) {
+        return;
+      }
+      seen.add(normalized);
+      sanitized.push(normalized);
+    });
+    if (!sanitized.length) {
+      return [...DEFAULT_CRIT_CONFETTI_COLORS];
+    }
+    return sanitized;
+  }
+
+  const DEFAULT_CRIT_CONFETTI_SHAPES = Object.freeze([
+    { className: 'crit-confetti--circle', widthFactor: 1, heightFactor: 1 },
+    { className: 'crit-confetti--oval', widthFactor: 1.4, heightFactor: 1 },
+    { className: 'crit-confetti--heart', widthFactor: 1.1, heightFactor: 1.1 },
+    { className: 'crit-confetti--star', widthFactor: 1.2, heightFactor: 1.2 },
+    { className: 'crit-confetti--square', widthFactor: 1, heightFactor: 1 },
+    { className: 'crit-confetti--triangle', widthFactor: 1.15, heightFactor: 1.3 },
+    { className: 'crit-confetti--rectangle', widthFactor: 1.8, heightFactor: 0.7 },
+    { className: 'crit-confetti--hexagon', widthFactor: 1.1, heightFactor: 1 }
+  ]);
+
+  function sanitizeConfettiShapes(raw) {
+    const base = Array.isArray(raw) ? raw : [];
+    const sanitized = [];
+    base.forEach(entry => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const rawClassName = entry.className ?? entry.class ?? entry.name ?? entry.id;
+      const className = rawClassName ? String(rawClassName).trim() : '';
+      if (!className) {
+        return;
+      }
+      const width = Number(entry.widthFactor ?? entry.width ?? entry.w ?? entry.scaleX ?? entry.scale ?? entry.size ?? 1);
+      const height = Number(entry.heightFactor ?? entry.height ?? entry.h ?? entry.scaleY ?? entry.scale ?? entry.size ?? 1);
+      const normalizedWidth = Number.isFinite(width) && width > 0 ? width : 1;
+      const normalizedHeight = Number.isFinite(height) && height > 0 ? height : 1;
+      sanitized.push({
+        className,
+        widthFactor: normalizedWidth,
+        heightFactor: normalizedHeight
+      });
+    });
+    if (!sanitized.length) {
+      return DEFAULT_CRIT_CONFETTI_SHAPES.map(entry => ({
+        className: entry.className,
+        widthFactor: entry.widthFactor,
+        heightFactor: entry.heightFactor
+      }));
+    }
+    return sanitized;
+  }
+
+  const MUSIC_SUPPORTED_EXTENSIONS = sanitizeMusicExtensions(
+    existingAppData?.MUSIC_SUPPORTED_EXTENSIONS ?? global.MUSIC_SUPPORTED_EXTENSIONS
+  );
+
+  const MUSIC_FALLBACK_TRACKS = sanitizeFallbackTracks(
+    existingAppData?.MUSIC_FALLBACK_TRACKS ?? global.MUSIC_FALLBACK_TRACKS
+  );
+
+  const GLOW_STOPS = sanitizeGlowStops(existingAppData?.GLOW_STOPS ?? global.GLOW_STOPS);
+
+  const CRIT_CONFETTI_COLORS = sanitizeConfettiColors(existingAppData?.CRIT_CONFETTI_COLORS ?? global.CRIT_CONFETTI_COLORS);
+
+  const CRIT_CONFETTI_SHAPES = sanitizeConfettiShapes(existingAppData?.CRIT_CONFETTI_SHAPES ?? global.CRIT_CONFETTI_SHAPES);
+
+  const appData = existingAppData ? { ...existingAppData } : {};
+  appData.DEFAULT_ATOM_SCALE_TROPHY_DATA = DEFAULT_ATOM_SCALE_TROPHY_DATA;
+  appData.ATOM_SCALE_TROPHY_DATA = ATOM_SCALE_TROPHY_DATA;
+  appData.FALLBACK_MILESTONES = FALLBACK_MILESTONES;
+  appData.FALLBACK_TROPHIES = FALLBACK_TROPHIES;
+  appData.DEFAULT_MUSIC_SUPPORTED_EXTENSIONS = [...DEFAULT_MUSIC_SUPPORTED_EXTENSIONS];
+  appData.MUSIC_SUPPORTED_EXTENSIONS = [...MUSIC_SUPPORTED_EXTENSIONS];
+  appData.DEFAULT_MUSIC_FALLBACK_TRACKS = [...DEFAULT_MUSIC_FALLBACK_TRACKS];
+  appData.MUSIC_FALLBACK_TRACKS = [...MUSIC_FALLBACK_TRACKS];
+  appData.DEFAULT_GLOW_STOPS = DEFAULT_GLOW_STOPS.map(entry => ({ stop: entry.stop, color: [...entry.color] }));
+  appData.GLOW_STOPS = GLOW_STOPS.map(entry => ({ stop: entry.stop, color: [...entry.color] }));
+  appData.DEFAULT_CRIT_CONFETTI_COLORS = [...DEFAULT_CRIT_CONFETTI_COLORS];
+  appData.CRIT_CONFETTI_COLORS = [...CRIT_CONFETTI_COLORS];
+  appData.DEFAULT_CRIT_CONFETTI_SHAPES = DEFAULT_CRIT_CONFETTI_SHAPES.map(entry => ({
+    className: entry.className,
+    widthFactor: entry.widthFactor,
+    heightFactor: entry.heightFactor
+  }));
+  appData.CRIT_CONFETTI_SHAPES = CRIT_CONFETTI_SHAPES.map(entry => ({
+    className: entry.className,
+    widthFactor: entry.widthFactor,
+    heightFactor: entry.heightFactor
+  }));
+  global.APP_DATA = appData;
+})(typeof globalThis !== 'undefined' ? globalThis : window);


### PR DESCRIPTION
## Summary
- add reusable sanitizers in app-data.js to expose music, glow, and confetti configuration through APP_DATA
- update app.js to consume the shared APP_DATA values for music fallback tracks, glow stops, and crit confetti assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7fb47b7c8832ebadb9373bd08822c