### PR TITLE
Add Métaux shortcut to Particules Mach3 banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,10 +154,24 @@
             <span class="arcade-header__status-label">Tickets</span>
             <span class="arcade-header__status-value" id="arcadeTicketValue">0 ticket</span>
           </button>
-          <div class="arcade-header__status arcade-header__status--info" id="arcadeBonusTicketDisplay" role="status" aria-live="polite">
+          <button
+            class="arcade-header__status arcade-header__status--bonus"
+            id="arcadeBonusTicketButton"
+            type="button"
+            aria-describedby="arcadeBonusTicketAnnouncement"
+            aria-disabled="true"
+            disabled
+          >
             <span class="arcade-header__status-label">Mach3</span>
             <span class="arcade-header__status-value" id="arcadeBonusTicketValue">0</span>
-          </div>
+          </button>
+          <span
+            id="arcadeBonusTicketAnnouncement"
+            class="visually-hidden"
+            aria-live="polite"
+          >
+            Mach3 : 0 crédits
+          </span>
         </div>
       </header>
 
@@ -439,7 +453,7 @@
                   id="metauxReturnButton"
                   class="metaux-end-screen__button metaux-end-screen__button--ghost"
                 >
-                  Options
+                  Retour
                 </button>
               </div>
               <p id="metauxCreditStatus" class="metaux-credit-status" role="status" aria-live="polite"></p>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1417,8 +1417,9 @@ const elements = {
   arcadeReturnButton: document.getElementById('arcadeReturnButton'),
   arcadeTicketButton: document.getElementById('arcadeTicketButton'),
   arcadeTicketValue: document.getElementById('arcadeTicketValue'),
-  arcadeBonusTicketDisplay: document.getElementById('arcadeBonusTicketDisplay'),
+  arcadeBonusTicketButton: document.getElementById('arcadeBonusTicketButton'),
   arcadeBonusTicketValue: document.getElementById('arcadeBonusTicketValue'),
+  arcadeBonusTicketAnnouncement: document.getElementById('arcadeBonusTicketAnnouncement'),
   arcadeCanvas: document.getElementById('arcadeGameCanvas'),
   arcadeParticleLayer: document.getElementById('arcadeParticleLayer'),
   arcadeOverlay: document.getElementById('arcadeOverlay'),
@@ -1587,9 +1588,21 @@ function updateArcadeTicketDisplay() {
   if (elements.arcadeBonusTicketValue) {
     elements.arcadeBonusTicketValue.textContent = bonusCount.toLocaleString('fr-FR');
   }
-  if (elements.arcadeBonusTicketDisplay) {
-    elements.arcadeBonusTicketDisplay.title = `Mach3 : ${formatBonusTicketLabel(bonusCount)}`;
-    elements.arcadeBonusTicketDisplay.setAttribute('aria-label', `Mach3 : ${formatBonusTicketLabel(bonusCount)}`);
+  const bonusLabel = formatMetauxCreditLabel(bonusCount);
+  if (elements.arcadeBonusTicketAnnouncement) {
+    elements.arcadeBonusTicketAnnouncement.textContent = `Mach3 : ${bonusLabel}`;
+  }
+  if (elements.arcadeBonusTicketButton) {
+    const hasCredits = bonusCount > 0;
+    elements.arcadeBonusTicketButton.disabled = !hasCredits;
+    elements.arcadeBonusTicketButton.setAttribute('aria-disabled', hasCredits ? 'false' : 'true');
+    if (hasCredits) {
+      elements.arcadeBonusTicketButton.title = `Lancer Métaux — ${bonusLabel}`;
+      elements.arcadeBonusTicketButton.setAttribute('aria-label', `Ouvrir Métaux (Mach3 : ${bonusLabel})`);
+    } else {
+      elements.arcadeBonusTicketButton.title = 'Attrapez un graviton pour gagner un Mach3.';
+      elements.arcadeBonusTicketButton.setAttribute('aria-label', 'Mach3 indisponible — attrapez un graviton.');
+    }
   }
   updateMetauxCreditsUI();
 }
@@ -4509,7 +4522,7 @@ if (elements.metauxExitButton) {
 
 if (elements.metauxReturnButton) {
   elements.metauxReturnButton.addEventListener('click', () => {
-    showPage('options');
+    showPage('game');
   });
 }
 
@@ -4576,6 +4589,15 @@ if (elements.arcadeTicketButton) {
       return;
     }
     showPage('gacha');
+  });
+}
+
+if (elements.arcadeBonusTicketButton) {
+  elements.arcadeBonusTicketButton.addEventListener('click', () => {
+    if (elements.arcadeBonusTicketButton.disabled) {
+      return;
+    }
+    showPage('metaux');
   });
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -691,8 +691,29 @@ main {
   border-color: rgba(255, 255, 255, 0.14);
 }
 
+.arcade-header__status--bonus {
+  background: linear-gradient(135deg, rgba(52, 72, 156, 0.8), rgba(86, 116, 224, 0.72));
+  border-color: rgba(110, 142, 255, 0.45);
+}
+
 .arcade-header__status--info .arcade-header__status-value {
   font-size: clamp(0.53rem, 0.99vw, 0.72rem);
+}
+
+.arcade-header__status[disabled],
+.arcade-header__status[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+  transform: none;
+}
+
+.arcade-header__status[disabled]:hover,
+.arcade-header__status[disabled]:focus-visible,
+.arcade-header__status[aria-disabled='true']:hover,
+.arcade-header__status[aria-disabled='true']:focus-visible {
+  box-shadow: none;
+  transform: none;
 }
 
 .arcade-header__status:hover,
@@ -743,6 +764,11 @@ body.theme-light .arcade-header__status--info {
   border-color: rgba(48, 64, 120, 0.2);
 }
 
+body.theme-light .arcade-header__status--bonus {
+  background: linear-gradient(135deg, rgba(208, 220, 255, 0.92), rgba(176, 196, 255, 0.82));
+  border-color: rgba(96, 124, 220, 0.3);
+}
+
 body.theme-light .arcade-header__status:focus-visible {
   outline-color: rgba(40, 48, 96, 0.7);
 }
@@ -765,6 +791,11 @@ body.theme-neon .arcade-header__status {
 body.theme-neon .arcade-header__status--info {
   background: rgba(54, 46, 150, 0.82);
   border-color: rgba(160, 190, 255, 0.4);
+}
+
+body.theme-neon .arcade-header__status--bonus {
+  background: linear-gradient(135deg, rgba(94, 28, 152, 0.92), rgba(170, 96, 255, 0.78));
+  border-color: rgba(210, 160, 255, 0.6);
 }
 
 .arcade-content {


### PR DESCRIPTION
## Summary
- add a Mach3 button in the Particules arcade header that opens Métaux when credits are available
- refresh the Mach3 counter accessibility and styling for the new interactive button
- rename the Métaux end-screen return button and redirect it to the main Atom2Univers page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d810acd334832eb0de3c167641af8c