### PR TITLE
feat: boost graviton spawn and add linger multiball bonus

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -741,10 +741,10 @@ const GAME_CONFIG = {
       graviton: {
         lifetimeMs: 10000,
         spawnChance: {
-          base: 0.05,
-          perLevel: 0.015,
-          min: 0.05,
-          max: 0.18
+          base: 0.15,
+          perLevel: 0.05,
+          min: 0.15,
+          max: 0.5
         },
         detectionMessage: 'Graviton détecté !',
         detectionMessageDurationMs: 2600,
@@ -752,6 +752,13 @@ const GAME_CONFIG = {
         dissipateMessageDurationMs: 2800,
         captureMessage: 'Graviton capturé ! Ticket spécial +1',
         captureMessageDurationMs: 3600
+      },
+      lingerBonus: {
+        thresholdMs: 20000,
+        intervalMs: 1000,
+        chance: 0.1,
+        message: 'Multiballe bonus !',
+        messageDurationMs: 2400
       },
       combos: {
         requiredColors: ['red', 'green', 'blue'],


### PR DESCRIPTION
## Summary
- raise the default graviton spawn progression to reach 50% at higher stages
- add a configurable linger bonus that periodically grants a free multiball after 20s on the same board

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d817434fdc832e9179325951f6f06e