### PR TITLE
feat: replace APC critical confetti with bouncing atom

### DIFF
--- a/scripts/modules/app-data.js
+++ b/scripts/modules/app-data.js
@@ -411,74 +411,30 @@
     return sanitized;
   }
 
-  const DEFAULT_CRIT_CONFETTI_COLORS = Object.freeze([
-    '#ff8ba7', '#ffd166', '#6fffe9', '#a5b4ff', '#ff9ff3',
-    '#70d6ff', '#fcd5ce', '#caffbf', '#bdb2ff', '#ffe066'
+  const DEFAULT_CRIT_ATOM_IMAGES = Object.freeze([
+    'Assets/Image/Atom.png'
   ]);
 
-  function sanitizeConfettiColors(raw) {
+  function sanitizeCritAtomImages(raw) {
     const candidates = Array.isArray(raw) ? raw : [];
-    const seen = new Set();
     const sanitized = [];
     candidates.forEach(entry => {
       const value = typeof entry === 'string'
         ? entry
-        : (entry && typeof entry === 'object' ? entry.color ?? entry.value ?? null : null);
+        : (entry && typeof entry === 'object'
+          ? entry.src ?? entry.url ?? entry.path ?? entry.href ?? null
+          : null);
       if (!value) {
         return;
       }
       const normalized = String(value).trim();
-      if (!normalized || seen.has(normalized)) {
+      if (!normalized || sanitized.includes(normalized)) {
         return;
       }
-      seen.add(normalized);
       sanitized.push(normalized);
     });
     if (!sanitized.length) {
-      return [...DEFAULT_CRIT_CONFETTI_COLORS];
-    }
-    return sanitized;
-  }
-
-  const DEFAULT_CRIT_CONFETTI_SHAPES = Object.freeze([
-    { className: 'crit-confetti--circle', widthFactor: 1, heightFactor: 1 },
-    { className: 'crit-confetti--oval', widthFactor: 1.4, heightFactor: 1 },
-    { className: 'crit-confetti--heart', widthFactor: 1.1, heightFactor: 1.1 },
-    { className: 'crit-confetti--star', widthFactor: 1.2, heightFactor: 1.2 },
-    { className: 'crit-confetti--square', widthFactor: 1, heightFactor: 1 },
-    { className: 'crit-confetti--triangle', widthFactor: 1.15, heightFactor: 1.3 },
-    { className: 'crit-confetti--rectangle', widthFactor: 1.8, heightFactor: 0.7 },
-    { className: 'crit-confetti--hexagon', widthFactor: 1.1, heightFactor: 1 }
-  ]);
-
-  function sanitizeConfettiShapes(raw) {
-    const base = Array.isArray(raw) ? raw : [];
-    const sanitized = [];
-    base.forEach(entry => {
-      if (!entry || typeof entry !== 'object') {
-        return;
-      }
-      const rawClassName = entry.className ?? entry.class ?? entry.name ?? entry.id;
-      const className = rawClassName ? String(rawClassName).trim() : '';
-      if (!className) {
-        return;
-      }
-      const width = Number(entry.widthFactor ?? entry.width ?? entry.w ?? entry.scaleX ?? entry.scale ?? entry.size ?? 1);
-      const height = Number(entry.heightFactor ?? entry.height ?? entry.h ?? entry.scaleY ?? entry.scale ?? entry.size ?? 1);
-      const normalizedWidth = Number.isFinite(width) && width > 0 ? width : 1;
-      const normalizedHeight = Number.isFinite(height) && height > 0 ? height : 1;
-      sanitized.push({
-        className,
-        widthFactor: normalizedWidth,
-        heightFactor: normalizedHeight
-      });
-    });
-    if (!sanitized.length) {
-      return DEFAULT_CRIT_CONFETTI_SHAPES.map(entry => ({
-        className: entry.className,
-        widthFactor: entry.widthFactor,
-        heightFactor: entry.heightFactor
-      }));
+      return [...DEFAULT_CRIT_ATOM_IMAGES];
     }
     return sanitized;
   }
@@ -493,9 +449,7 @@
 
   const GLOW_STOPS = sanitizeGlowStops(existingAppData?.GLOW_STOPS ?? global.GLOW_STOPS);
 
-  const CRIT_CONFETTI_COLORS = sanitizeConfettiColors(existingAppData?.CRIT_CONFETTI_COLORS ?? global.CRIT_CONFETTI_COLORS);
-
-  const CRIT_CONFETTI_SHAPES = sanitizeConfettiShapes(existingAppData?.CRIT_CONFETTI_SHAPES ?? global.CRIT_CONFETTI_SHAPES);
+  const CRIT_ATOM_IMAGES = sanitizeCritAtomImages(existingAppData?.CRIT_ATOM_IMAGES ?? global.CRIT_ATOM_IMAGES);
 
   const appData = existingAppData ? { ...existingAppData } : {};
   appData.DEFAULT_ATOM_SCALE_TROPHY_DATA = DEFAULT_ATOM_SCALE_TROPHY_DATA;
@@ -508,17 +462,7 @@
   appData.MUSIC_FALLBACK_TRACKS = [...MUSIC_FALLBACK_TRACKS];
   appData.DEFAULT_GLOW_STOPS = DEFAULT_GLOW_STOPS.map(entry => ({ stop: entry.stop, color: [...entry.color] }));
   appData.GLOW_STOPS = GLOW_STOPS.map(entry => ({ stop: entry.stop, color: [...entry.color] }));
-  appData.DEFAULT_CRIT_CONFETTI_COLORS = [...DEFAULT_CRIT_CONFETTI_COLORS];
-  appData.CRIT_CONFETTI_COLORS = [...CRIT_CONFETTI_COLORS];
-  appData.DEFAULT_CRIT_CONFETTI_SHAPES = DEFAULT_CRIT_CONFETTI_SHAPES.map(entry => ({
-    className: entry.className,
-    widthFactor: entry.widthFactor,
-    heightFactor: entry.heightFactor
-  }));
-  appData.CRIT_CONFETTI_SHAPES = CRIT_CONFETTI_SHAPES.map(entry => ({
-    className: entry.className,
-    widthFactor: entry.widthFactor,
-    heightFactor: entry.heightFactor
-  }));
+  appData.DEFAULT_CRIT_ATOM_IMAGES = [...DEFAULT_CRIT_ATOM_IMAGES];
+  appData.CRIT_ATOM_IMAGES = [...CRIT_ATOM_IMAGES];
   global.APP_DATA = appData;
 })(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/styles/main.css
+++ b/styles/main.css
@@ -2532,88 +2532,37 @@ body.theme-neon .page--void {
   --critical-flash: 1;
 }
 
-.crit-confetti-layer {
+.crit-atom-layer {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  overflow: hidden;
   z-index: 40;
 }
 
-.crit-confetti {
+.crit-atom {
   position: absolute;
   display: block;
-  transform: translate(-50%, -50%) scale(var(--confetti-scale, 1)) rotate(var(--confetti-rotation, 0deg));
+  width: var(--crit-atom-size, 100px);
+  height: auto;
+  transform: translate3d(var(--crit-atom-x, 0), var(--crit-atom-y, 0), 0)
+    rotate(var(--crit-atom-rotation, 0deg))
+    scale(var(--crit-atom-scale, 1));
+  transform-origin: center;
   opacity: 0;
-  border-radius: 0.35rem;
-  background-size: 140% 140%;
-  background-position: center;
-  animation: crit-confetti-float var(--confetti-duration, 3s) ease-in-out forwards;
-  animation-delay: var(--confetti-delay, 0s);
   pointer-events: none;
-  mix-blend-mode: screen;
+  transition: opacity 0.4s ease;
+  will-change: transform, opacity;
+  filter:
+    drop-shadow(0 8px 18px rgba(0, 0, 0, 0.22))
+    drop-shadow(0 0 14px rgba(255, 255, 255, 0.4));
 }
 
-.crit-confetti--circle {
-  border-radius: 50%;
+.crit-atom.is-active {
+  opacity: 1;
 }
 
-.crit-confetti--oval {
-  border-radius: 48% / 70%;
-}
-
-.crit-confetti--heart {
-  border-radius: 0;
-  clip-path: polygon(50% 14%, 61% 0, 78% 0, 93% 14%, 100% 32%, 95% 52%, 78% 74%, 50% 100%, 22% 74%, 5% 52%, 0 32%, 7% 14%, 22% 0, 39% 0);
-}
-
-.crit-confetti--star {
-  border-radius: 0;
-  clip-path: polygon(50% 0%, 62% 35%, 100% 38%, 70% 60%, 82% 100%, 50% 78%, 18% 100%, 30% 60%, 0% 38%, 38% 35%);
-}
-
-.crit-confetti--square {
-  border-radius: 0.2rem;
-}
-
-.crit-confetti--triangle {
-  border-radius: 0;
-  clip-path: polygon(50% 6%, 0% 100%, 100% 100%);
-}
-
-.crit-confetti--rectangle {
-  border-radius: 0.45rem;
-}
-
-.crit-confetti--hexagon {
-  border-radius: 0;
-  clip-path: polygon(25% 6.5%, 75% 6.5%, 100% 50%, 75% 93.5%, 25% 93.5%, 0% 50%);
-}
-
-@keyframes crit-confetti-float {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(var(--confetti-scale, 1)) rotate(var(--confetti-rotation, 0deg));
-  }
-  12% {
-    opacity: 1;
-  }
-  68% {
-    opacity: 1;
-    transform: translate(
-      calc(-50% + var(--confetti-drift-x, 0px)),
-      calc(-50% + var(--confetti-drift-y, 0px))
-    ) scale(var(--confetti-scale, 1)) rotate(var(--confetti-end-rotation, 0deg));
-  }
-  100% {
-    opacity: 0;
-    transform: translate(
-      calc(-50% + var(--confetti-end-x, 0px)),
-      calc(-50% + var(--confetti-end-y, 0px))
-    ) scale(var(--confetti-scale, 1)) rotate(
-      calc(var(--confetti-end-rotation, 0deg) + var(--confetti-spin, 90deg))
-    );
-  }
+.crit-atom.is-fading {
+  opacity: 0;
 }
 
 .atom-visual {


### PR DESCRIPTION
## Summary
- replace the APC critical confetti burst with a bouncing atom animation and supporting layer
- add configuration support for selecting critical atom sprite sources
- clean up stylesheet rules to remove confetti shapes and style the new atom effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8cfb69b04832e9c166fbd54584bc4