### PR TITLE
Hide locked shop and goals navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,26 @@
       </button>
       <nav class="nav-menu" aria-label="Navigation principale">
         <button class="nav-button active" data-target="game">Atoms</button>
-        <button class="nav-button" data-target="shop">Shop</button>
+        <button
+          class="nav-button"
+          data-target="shop"
+          hidden
+          aria-hidden="true"
+          disabled
+          aria-disabled="true"
+        >Shop</button>
         <button class="nav-button" data-target="gacha" hidden aria-hidden="true">Gacha</button>
         <button class="nav-button" data-target="tableau" hidden aria-hidden="true">Table</button>
         <button class="nav-button" data-target="fusion" hidden aria-hidden="true">Fusion</button>
         <button class="nav-button" data-target="info" hidden aria-hidden="true">Infos</button>
-        <button class="nav-button" data-target="goals">Goals</button>
+        <button
+          class="nav-button"
+          data-target="goals"
+          hidden
+          aria-hidden="true"
+          disabled
+          aria-disabled="true"
+        >Goals</button>
         <button class="nav-button" data-target="bigbang" id="navBigBangButton" hidden aria-hidden="true">Big Bang</button>
         <button class="nav-button" data-target="options">Options</button>
       </nav>


### PR DESCRIPTION
## Summary
- hide the shop button until the main atom counter reaches 15
- hide the goals button until the first million-atoms trophy is unlocked
- centralize navigation lock handling so hidden pages cannot remain active

## Testing
- _No automated tests were run (not requested)_

------
https://chatgpt.com/codex/tasks/task_e_68d8d4649c84832eb20858622c2ffd1f