### PR TITLE
Add new critical atom variants

### DIFF
--- a/scripts/modules/app-data.js
+++ b/scripts/modules/app-data.js
@@ -412,7 +412,14 @@
   }
 
   const DEFAULT_CRIT_ATOM_IMAGES = Object.freeze([
-    'Assets/Image/Atom.png'
+    'Assets/Image/Atom.png',
+    'Assets/Image/Atom0.png',
+    'Assets/Image/Atom1.png',
+    'Assets/Image/Atom2.png',
+    'Assets/Image/Atom3.png',
+    'Assets/Image/Atom4.png',
+    'Assets/Image/Atom5.png',
+    'Assets/Image/Atom6.png'
   ]);
 
   function sanitizeCritAtomImages(raw) {


### PR DESCRIPTION
## Summary
- extend the default critical atom sprite list to include Atom0 through Atom6 images
- allow the APC critical effect to randomly pick from the new variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d840f888832eb549bfec925b8692