### PR TITLE
Add weekly featured gacha rarity banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
 
     <section id="gacha" class="page page--gacha" aria-labelledby="gacha-title">
       <h2 id="gacha-title" class="visually-hidden">Portail de tirage cosmique</h2>
+      <div class="gacha-featured-info" id="gachaFeaturedInfo" aria-live="polite" hidden></div>
       <div class="gacha-ticket-counter" id="gachaTicketCounter" aria-live="polite">
         <button
           class="gacha-ticket-mode"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1442,6 +1442,7 @@ const elements = {
   gachaRarityList: document.getElementById('gachaRarityList'),
   gachaOwnedSummary: document.getElementById('gachaOwnedSummary'),
   gachaSunButton: document.getElementById('gachaSunButton'),
+  gachaFeaturedInfo: document.getElementById('gachaFeaturedInfo'),
   gachaTicketCounter: document.getElementById('gachaTicketCounter'),
   gachaTicketModeButton: document.getElementById('gachaTicketModeButton'),
   gachaTicketModeLabel: document.getElementById('gachaTicketModeLabel'),

--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -106,6 +106,15 @@ const BASE_GACHA_RARITY_ID_SET = new Set(BASE_GACHA_RARITIES.map(entry => entry.
 
 const WEEKDAY_KEYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
 
+const GACHA_FEATURED_LABELS_BY_DAY = Object.freeze({
+  monday: '+Singularité Minérale',
+  thursday: '+Singularité Minérale',
+  tuesday: '+Mythe Quantique',
+  friday: '+Mythe Quantique',
+  wednesday: '+Iréel',
+  saturday: '+Iréel'
+});
+
 function sanitizeWeeklyRarityWeights(rawWeights) {
   const sanitized = {};
   WEEKDAY_KEYS.forEach(day => {
@@ -196,7 +205,33 @@ function refreshGachaRarities(date = new Date(), { force = false } = {}) {
     GACHA_RARITY_MAP.set(entry.id, entry);
   });
   activeGachaWeightDayKey = dayKey;
+  updateGachaFeaturedInfo(dayKey);
   return true;
+}
+
+function getGachaFeaturedLabelForDayKey(dayKey) {
+  if (!dayKey) {
+    return null;
+  }
+  return GACHA_FEATURED_LABELS_BY_DAY[dayKey] ?? null;
+}
+
+function updateGachaFeaturedInfo(dayKey = WEEKDAY_KEYS[new Date().getDay()] ?? null) {
+  if (typeof elements === 'undefined' || !elements) {
+    return;
+  }
+  const featuredInfo = elements.gachaFeaturedInfo;
+  if (!featuredInfo) {
+    return;
+  }
+  const label = getGachaFeaturedLabelForDayKey(dayKey);
+  if (label) {
+    featuredInfo.textContent = label;
+    featuredInfo.hidden = false;
+  } else {
+    featuredInfo.textContent = '';
+    featuredInfo.hidden = true;
+  }
 }
 
 function getCurrentGachaTotalWeight() {
@@ -1759,6 +1794,7 @@ let gachaAnimationInProgress = false;
 let gachaRollMode = 1;
 
 function updateGachaUI() {
+  updateGachaFeaturedInfo();
   const available = Math.max(0, Math.floor(Number(gameState.gachaTickets) || 0));
   if (elements.gachaTicketValue) {
     elements.gachaTicketValue.textContent = formatTicketLabel(available);

--- a/styles/main.css
+++ b/styles/main.css
@@ -1537,6 +1537,20 @@ body.theme-light .fusion-log.fusion-log--failure {
   display: flex;
 }
 
+.gacha-featured-info {
+  position: absolute;
+  top: clamp(1rem, 3vw, 2rem);
+  left: clamp(1rem, 3vw, 2rem);
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+  pointer-events: none;
+  user-select: none;
+  white-space: nowrap;
+}
+
 .gacha-ticket-counter {
   position: absolute;
   top: clamp(1rem, 3vw, 2rem);
@@ -1609,10 +1623,18 @@ body.theme-light .gacha-ticket-counter {
   box-shadow: 0 12px 24px rgba(10, 14, 28, 0.12);
 }
 
+body.theme-light .gacha-featured-info {
+  color: rgba(12, 16, 32, 0.65);
+}
+
 body.theme-neon .gacha-ticket-counter {
   background: rgba(70, 90, 220, 0.65);
   color: #f6f8ff;
   box-shadow: 0 14px 32px rgba(40, 60, 160, 0.45);
+}
+
+body.theme-neon .gacha-featured-info {
+  color: rgba(232, 236, 255, 0.82);
 }
 
 .gacha-sun-button {


### PR DESCRIPTION
## Summary
- add a day-specific featured rarity label to the gacha screen
- style the banner to sit opposite the ticket counter and match active theme colors
- update the gacha UI logic to surface the correct label for each weekday

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8dfb50324832eb5d0a8bd472d83ff