### PR TITLE
Gate offline ticket rewards and diversify ticket star spawns

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -7519,7 +7519,8 @@ function loadGame() {
           showToast(`Progression hors ligne : +${offlineGain.toString()} atomes`);
         }
       }
-      if (diff > 0) {
+      const hasFirstTrophy = getUnlockedTrophySet().has(ARCADE_TROPHY_ID);
+      if (diff > 0 && hasFirstTrophy) {
         const offlineTickets = gameState.offlineTickets || {
           secondsPerTicket: OFFLINE_TICKET_CONFIG.secondsPerTicket,
           capSeconds: OFFLINE_TICKET_CONFIG.capSeconds,
@@ -7557,6 +7558,14 @@ function loadGame() {
           secondsPerTicket,
           capSeconds,
           progressSeconds
+        };
+      } else if (!hasFirstTrophy) {
+        const secondsPerTicket = OFFLINE_TICKET_CONFIG.secondsPerTicket;
+        const capSeconds = Math.max(OFFLINE_TICKET_CONFIG.capSeconds, secondsPerTicket);
+        gameState.offlineTickets = {
+          secondsPerTicket,
+          capSeconds,
+          progressSeconds: 0
         };
       }
     }

--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -2693,7 +2693,8 @@ const ticketStarState = {
   width: 0,
   height: 0,
   nextSpawnTime: performance.now() + computeTicketStarDelay(),
-  spawnTime: 0
+  spawnTime: 0,
+  lastSpawnEdge: null
 };
 
 function resetTicketStarState(options = {}) {
@@ -2709,6 +2710,7 @@ function resetTicketStarState(options = {}) {
   ticketStarState.width = 0;
   ticketStarState.height = 0;
   ticketStarState.spawnTime = 0;
+  ticketStarState.lastSpawnEdge = null;
   const now = performance.now();
   if (!isTicketStarFeatureUnlocked()) {
     ticketStarState.nextSpawnTime = Number.POSITIVE_INFINITY;
@@ -2746,6 +2748,7 @@ function collectTicketStar(event) {
   ticketStarState.velocity.y = 0;
   ticketStarState.position.x = 0;
   ticketStarState.position.y = 0;
+  ticketStarState.lastSpawnEdge = null;
   ticketStarState.nextSpawnTime = performance.now() + computeTicketStarDelay();
   saveGame();
 }
@@ -2789,7 +2792,15 @@ function spawnTicketStar(now = performance.now()) {
   let startX = Math.random() * maxX;
   let startY = Math.random() * maxY;
   const edges = ['top', 'right', 'bottom', 'left'];
-  const edge = edges[Math.floor(Math.random() * edges.length)] ?? 'top';
+  let edgePool = edges;
+  if (ticketStarState.lastSpawnEdge && edges.length > 1) {
+    const filtered = edges.filter(entry => entry !== ticketStarState.lastSpawnEdge);
+    if (filtered.length) {
+      edgePool = filtered;
+    }
+  }
+  const edge = edgePool[Math.floor(Math.random() * edgePool.length)] ?? 'top';
+  ticketStarState.lastSpawnEdge = edge;
   let angle;
   switch (edge) {
     case 'top':
@@ -2837,6 +2848,7 @@ function updateTicketStar(deltaSeconds, now = performance.now()) {
       ticketStarState.element = null;
       ticketStarState.active = false;
       ticketStarState.spawnTime = 0;
+      ticketStarState.lastSpawnEdge = null;
     }
     ticketStarState.nextSpawnTime = Number.POSITIVE_INFINITY;
     return;
@@ -2855,6 +2867,7 @@ function updateTicketStar(deltaSeconds, now = performance.now()) {
     ticketStarState.active = false;
     ticketStarState.nextSpawnTime = now + computeTicketStarDelay();
     ticketStarState.spawnTime = 0;
+    ticketStarState.lastSpawnEdge = null;
     return;
   }
   const layer = elements.ticketLayer;


### PR DESCRIPTION
## Summary
- prevent offline ticket generation until the first "Ruée vers le million" trophy is unlocked
- reset offline ticket progress when the trophy is missing
- ensure ticket-star spawns rotate between screen edges to vary their entry direction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fb422488832e9a296ee26df26dbc