### PR TITLE
Add metallic and neon brick skins to Particules

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -943,7 +943,8 @@ const GAME_CONFIG = {
             bonus: 0.2,
             max: 0.2
           }
-        }
+        },
+        skin: null
       },
       particles: {
         simple: [


### PR DESCRIPTION
## Summary
- register the new metallic_bricks and neon_bricks sprite sheets for the brick renderer
- add a per-brick skin override that safely clones particle sprites and randomizes column choice when applicable
- expose a `skin` option in the arcade configuration so metallic/neon skins can be selected

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8fe739e10832eadc42d7de1fe1b64