### PR TITLE
Add unlockable brick skin selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,6 +512,20 @@
             La musique démarre automatiquement après votre première interaction.
           </p>
         </div>
+        <div class="option-card" id="brickSkinOptionCard" hidden aria-hidden="true">
+          <h3>Skin des briques</h3>
+          <div class="option-row">
+            <label for="brickSkinSelect">Apparence</label>
+            <select id="brickSkinSelect" disabled>
+              <option value="original">Original</option>
+              <option value="metallic">Metallic</option>
+              <option value="neon">Néon</option>
+            </select>
+          </div>
+          <p class="option-note" id="brickSkinStatus">
+            Débloquez le trophée « Ruée vers le million » pour personnaliser vos briques.
+          </p>
+        </div>
       </div>
       <div class="options-reset">
         <button id="resetButton" class="danger">Réinitialiser</button>

--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -1840,7 +1840,29 @@ function updateGachaUI() {
 }
 
 
+let particulesBrickSkinPreference = null;
 let particulesGame = null;
+
+function normalizeParticulesBrickSkin(value) {
+  if (value == null) {
+    return null;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized || normalized === 'original' || normalized === 'default') {
+    return null;
+  }
+  if (normalized === 'metallic' || normalized === 'neon') {
+    return normalized;
+  }
+  return null;
+}
+
+function setParticulesBrickSkinPreference(value) {
+  particulesBrickSkinPreference = normalizeParticulesBrickSkin(value);
+  if (particulesGame && typeof particulesGame.setBrickSkin === 'function') {
+    particulesGame.setBrickSkin(particulesBrickSkinPreference);
+  }
+}
 
 function initParticulesGame() {
   if (particulesGame || !elements.arcadeCanvas || typeof ParticulesGame !== 'function') {
@@ -1856,6 +1878,7 @@ function initParticulesGame() {
     livesLabel: elements.arcadeLivesValue,
     scoreLabel: elements.arcadeScoreValue,
     comboLabel: elements.arcadeComboMessage,
+    brickSkin: particulesBrickSkinPreference,
     formatTicketLabel,
     formatBonusTicketLabel,
     onTicketsEarned: (count = 0) => {


### PR DESCRIPTION
## Summary
- add a hidden brick skin dropdown to the options page
- persist the brick skin setting and surface the selector once the million-atoms trophy is unlocked
- allow the Particules arcade game to swap brick sprite sheets at runtime when the skin changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9048f9454832e85401cd83b53f3e1