### PR TITLE
Add Photon mini-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,36 @@
       </div>
     </section>
 
+    <section id="photon" class="page page--photon" aria-label="Photon" hidden>
+      <div class="photon-window">
+        <header class="photon-header">
+          <h2 class="photon-title">Photon</h2>
+          <button
+            class="photon-close-button"
+            id="photonCloseButton"
+            type="button"
+            aria-label="Fermer Photon et retourner aux options"
+          >
+            ×
+          </button>
+        </header>
+        <div class="photon-stage" id="photonStage" role="application" aria-label="Zone de jeu Photon">
+          <canvas class="photon-canvas" id="photonCanvas" width="360" height="640"></canvas>
+          <div class="photon-hud" aria-live="polite">
+            <span class="photon-hud__label">Score</span>
+            <span class="photon-hud__value" id="photonScoreValue">0</span>
+          </div>
+          <p class="photon-hint">Cliquez ou touchez pour inverser la couleur du halo.</p>
+          <div class="photon-overlay" id="photonOverlay" hidden>
+            <div class="photon-overlay__panel" role="dialog" aria-modal="true" aria-labelledby="photonOverlayMessage">
+              <p class="photon-overlay__message" id="photonOverlayMessage">Prêt à synchroniser les photons ?</p>
+              <button type="button" class="photon-overlay__button" id="photonOverlayButton">Commencer</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section id="metaux" class="page page--metaux" aria-label="Métaux" hidden>
       <button
         class="metaux-exit-button"
@@ -489,6 +519,11 @@
             Débloquez le trophée « Ruée vers le million » pour personnaliser vos briques.
           </p>
         </div>
+        <div class="option-card option-card--photon">
+          <h3>Photon</h3>
+          <p class="option-note">Synchronisez la couleur du halo avec les faisceaux lumineux qui tombent.</p>
+          <button type="button" id="photonOpenButton" class="photon-launch-button">Lancer Photon</button>
+        </div>
       </div>
       <div class="options-reset">
         <button id="resetButton" class="danger">Réinitialiser</button>
@@ -555,6 +590,7 @@
   <script src="config/config.js"></script>
   <script src="scripts/utils.js"></script>
   <script src="scripts/particules.js"></script>
+  <script src="scripts/photon.js"></script>
   <script src="scripts/modules/layered-number.js"></script>
   <script src="scripts/modules/game-data.js"></script>
   <script src="scripts/modules/gacha.js"></script>

--- a/scripts/photon.js
+++ b/scripts/photon.js
@@ -1,0 +1,341 @@
+(() => {
+  const COLOR_DEFS = {
+    blue: {
+      bar: '#56a6ff',
+      barEdge: '#9ed2ff',
+      haloInner: 'rgba(86, 166, 255, 0.88)',
+      haloMid: 'rgba(86, 166, 255, 0.4)',
+      haloOuter: 'rgba(86, 166, 255, 0.08)'
+    },
+    red: {
+      bar: '#ff6b8d',
+      barEdge: '#ffc2d1',
+      haloInner: 'rgba(255, 107, 141, 0.9)',
+      haloMid: 'rgba(255, 107, 141, 0.42)',
+      haloOuter: 'rgba(255, 107, 141, 0.08)'
+    }
+  };
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  function drawRoundedRect(ctx, x, y, width, height, radius) {
+    const r = Math.min(radius, width / 2, height / 2);
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + width - r, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+    ctx.lineTo(x + width, y + height - r);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+    ctx.lineTo(x + r, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+  }
+
+  class PhotonGame {
+    constructor({ canvas, onScoreChange, onColorChange, onGameOver } = {}) {
+      this.canvas = canvas || null;
+      this.context = this.canvas ? this.canvas.getContext('2d') : null;
+      this.onScoreChange = typeof onScoreChange === 'function' ? onScoreChange : () => {};
+      this.onColorChange = typeof onColorChange === 'function' ? onColorChange : () => {};
+      this.onGameOver = typeof onGameOver === 'function' ? onGameOver : () => {};
+
+      this.viewportWidth = 0;
+      this.viewportHeight = 0;
+      this.currentColor = 'blue';
+      this.score = 0;
+      this.bars = [];
+      this.desiredBarCount = 3;
+      this.spawnGap = 90;
+      this.state = 'idle';
+      this.lastTimestamp = 0;
+      this.animationFrame = null;
+
+      this._tick = this._tick.bind(this);
+
+      if (this.context && this.canvas) {
+        this.resize();
+        this.render();
+      }
+    }
+
+    getBarWidth() {
+      const width = this.viewportWidth || 0;
+      if (!width) return 0;
+      return clamp(width * 0.42, 120, 220);
+    }
+
+    getBarHeight() {
+      const height = this.viewportHeight || 0;
+      if (!height) return 0;
+      return clamp(height * 0.23, 120, 180);
+    }
+
+    getBarSpeed() {
+      const height = this.viewportHeight || 0;
+      if (!height) return 180;
+      return clamp(height * 0.78, 180, 320);
+    }
+
+    getHaloHeight() {
+      const height = this.viewportHeight || 0;
+      if (!height) return 140;
+      return clamp(height * 0.22, 110, 180);
+    }
+
+    resize() {
+      if (!this.canvas || !this.context) {
+        return;
+      }
+      const rect = this.canvas.getBoundingClientRect();
+      const deviceRatio = typeof window !== 'undefined' && Number.isFinite(window.devicePixelRatio)
+        ? window.devicePixelRatio
+        : 1;
+      const ratio = clamp(deviceRatio, 1, 3);
+      const width = Math.max(1, rect.width);
+      const height = Math.max(1, rect.height);
+      const displayWidth = Math.floor(width * ratio);
+      const displayHeight = Math.floor(height * ratio);
+      if (this.canvas.width !== displayWidth || this.canvas.height !== displayHeight) {
+        this.canvas.width = displayWidth;
+        this.canvas.height = displayHeight;
+      }
+      this.context.setTransform(ratio, 0, 0, ratio, 0, 0);
+      this.viewportWidth = width;
+      this.viewportHeight = height;
+      this.render();
+    }
+
+    ensureBarSupply() {
+      if (!this.viewportHeight) {
+        return;
+      }
+      while (this.bars.length < this.desiredBarCount) {
+        this.spawnBar();
+      }
+    }
+
+    spawnBar() {
+      const barHeight = this.getBarHeight();
+      const topMost = this.bars.reduce((min, bar) => Math.min(min, bar.y), Infinity);
+      const startY = Number.isFinite(topMost)
+        ? Math.min(-barHeight, topMost - (barHeight + this.spawnGap))
+        : -barHeight;
+      const color = Math.random() < 0.5 ? 'blue' : 'red';
+      this.bars.push({
+        color,
+        y: startY,
+        height: barHeight,
+        resolved: false
+      });
+    }
+
+    start() {
+      if (!this.context) {
+        return;
+      }
+      this.stopLoop();
+      this.state = 'running';
+      this.score = 0;
+      this.currentColor = 'blue';
+      this.bars = [];
+      this.onColorChange(this.currentColor);
+      this.onScoreChange(this.score);
+      this.ensureBarSupply();
+      this.lastTimestamp = performance.now();
+      this.render();
+      this.animationFrame = requestAnimationFrame(this._tick);
+    }
+
+    stop() {
+      this.stopLoop();
+      this.state = 'idle';
+      this.bars = [];
+      this.currentColor = 'blue';
+      this.onColorChange(this.currentColor);
+      this.render();
+    }
+
+    pause() {
+      if (this.state !== 'running') {
+        return;
+      }
+      this.state = 'paused';
+      this.stopLoop();
+    }
+
+    resume() {
+      if (this.state !== 'paused') {
+        return;
+      }
+      this.state = 'running';
+      this.lastTimestamp = performance.now();
+      this.animationFrame = requestAnimationFrame(this._tick);
+    }
+
+    onEnter() {
+      this.resize();
+      if (this.state === 'paused') {
+        this.resume();
+      } else {
+        this.render();
+      }
+    }
+
+    onLeave() {
+      if (this.state === 'running') {
+        this.pause();
+      }
+    }
+
+    toggleColor() {
+      if (this.state !== 'running') {
+        return;
+      }
+      this.currentColor = this.currentColor === 'blue' ? 'red' : 'blue';
+      this.onColorChange(this.currentColor);
+      this.render();
+    }
+
+    stopLoop() {
+      if (this.animationFrame != null) {
+        cancelAnimationFrame(this.animationFrame);
+        this.animationFrame = null;
+      }
+    }
+
+    _tick(timestamp) {
+      if (this.state !== 'running') {
+        this.animationFrame = null;
+        return;
+      }
+      const deltaSeconds = clamp((timestamp - this.lastTimestamp) / 1000, 0, 0.12);
+      this.lastTimestamp = timestamp;
+      this.update(deltaSeconds);
+      this.render();
+      if (this.state === 'running') {
+        this.animationFrame = requestAnimationFrame(this._tick);
+      }
+    }
+
+    update(deltaSeconds) {
+      if (deltaSeconds <= 0 || !Number.isFinite(deltaSeconds)) {
+        return;
+      }
+      const speed = this.getBarSpeed();
+      let activeIndex = -1;
+      let activeBottom = -Infinity;
+      for (let i = 0; i < this.bars.length; i += 1) {
+        const bar = this.bars[i];
+        bar.y += speed * deltaSeconds;
+        const bottom = bar.y + bar.height;
+        if (bottom > activeBottom) {
+          activeBottom = bottom;
+          activeIndex = i;
+        }
+      }
+      const haloTop = (this.viewportHeight || 0) - this.getHaloHeight();
+      if (activeIndex >= 0) {
+        const activeBar = this.bars[activeIndex];
+        if (activeBar && !activeBar.resolved && activeBar.y + activeBar.height >= haloTop) {
+          if (activeBar.color === this.currentColor) {
+            this.resolveActiveBar(activeIndex);
+          } else {
+            this.triggerGameOver();
+            return;
+          }
+        }
+      }
+      // Clean up any bars that moved far beyond the screen
+      this.bars = this.bars.filter(bar => bar.y <= (this.viewportHeight || 0) + this.spawnGap * 2);
+      this.ensureBarSupply();
+    }
+
+    resolveActiveBar(index) {
+      const removed = this.bars.splice(index, 1);
+      if (removed.length) {
+        this.score += 1;
+        this.onScoreChange(this.score);
+      }
+      this.ensureBarSupply();
+    }
+
+    triggerGameOver() {
+      this.state = 'gameover';
+      this.stopLoop();
+      this.render();
+      this.onGameOver({ score: this.score, color: this.currentColor });
+    }
+
+    render() {
+      if (!this.context) {
+        return;
+      }
+      const ctx = this.context;
+      const width = this.viewportWidth || this.canvas?.width || 0;
+      const height = this.viewportHeight || this.canvas?.height || 0;
+      if (!width || !height) {
+        return;
+      }
+      ctx.save();
+      ctx.clearRect(0, 0, width, height);
+
+      const backgroundGradient = ctx.createLinearGradient(0, 0, 0, height);
+      backgroundGradient.addColorStop(0, '#090d19');
+      backgroundGradient.addColorStop(1, '#04060d');
+      ctx.fillStyle = backgroundGradient;
+      ctx.fillRect(0, 0, width, height);
+
+      const barWidth = this.getBarWidth();
+      const barX = (width - barWidth) / 2;
+      for (const bar of this.bars) {
+        const colors = COLOR_DEFS[bar.color] || COLOR_DEFS.blue;
+        const barGradient = ctx.createLinearGradient(barX, bar.y, barX + barWidth, bar.y + bar.height);
+        barGradient.addColorStop(0, colors.barEdge);
+        barGradient.addColorStop(0.2, colors.bar);
+        barGradient.addColorStop(0.8, colors.bar);
+        barGradient.addColorStop(1, colors.barEdge);
+        drawRoundedRect(ctx, barX, bar.y, barWidth, bar.height, Math.min(28, barWidth / 4));
+        ctx.fillStyle = barGradient;
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+
+      const haloHeight = this.getHaloHeight();
+      const haloTop = height - haloHeight;
+      const haloColors = COLOR_DEFS[this.currentColor] || COLOR_DEFS.blue;
+      const haloGradient = ctx.createLinearGradient(0, haloTop, 0, height);
+      haloGradient.addColorStop(0, haloColors.haloOuter);
+      haloGradient.addColorStop(0.45, haloColors.haloMid);
+      haloGradient.addColorStop(1, haloColors.haloInner);
+      ctx.fillStyle = haloGradient;
+      ctx.fillRect(0, haloTop, width, haloHeight);
+
+      const haloGlow = ctx.createRadialGradient(
+        width / 2,
+        height - haloHeight * 0.35,
+        haloHeight * 0.25,
+        width / 2,
+        height,
+        haloHeight
+      );
+      haloGlow.addColorStop(0, haloColors.haloInner);
+      haloGlow.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      ctx.fillStyle = haloGlow;
+      ctx.fillRect(0, haloTop, width, haloHeight);
+
+      const baseLineGradient = ctx.createLinearGradient(0, haloTop, 0, haloTop + 12);
+      baseLineGradient.addColorStop(0, 'rgba(255, 255, 255, 0.25)');
+      baseLineGradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+      ctx.fillStyle = baseLineGradient;
+      ctx.fillRect(barX * 0.2, haloTop - 6, width - barX * 0.4, 12);
+
+      ctx.restore();
+    }
+  }
+
+  window.PhotonGame = PhotonGame;
+})();

--- a/styles/main.css
+++ b/styles/main.css
@@ -70,6 +70,23 @@ body.view-arcade main {
   justify-content: center;
 }
 
+body.view-photon {
+  background: radial-gradient(140% 180% at 50% 0%, #141d45 0%, #070918 48%, #01030a 100%);
+}
+
+body.view-photon .app-header {
+  display: none;
+}
+
+body.view-photon .status-bar {
+  display: none;
+}
+
+body.view-photon main {
+  width: 100%;
+  justify-content: center;
+}
+
 body.theme-light .app-header {
   background: rgba(246, 247, 251, 0.78);
   border-bottom-color: rgba(12, 16, 32, 0.08);
@@ -589,6 +606,20 @@ main {
   min-height: 100vh;
 }
 
+.page--photon {
+  display: none;
+  width: 100%;
+  max-width: 100%;
+  padding: clamp(1.4rem, 4vw, 2.6rem);
+}
+
+.page--photon.active {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
 .arcade-header {
   display: flex;
   align-items: center;
@@ -636,6 +667,241 @@ main {
   display: flex;
   align-items: stretch;
   gap: clamp(0.28rem, 0.77vw, 0.55rem);
+}
+
+.photon-window {
+  width: min(460px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.9rem, 2vw, 1.3rem);
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, rgba(20, 28, 56, 0.92), rgba(6, 10, 28, 0.92));
+  box-shadow: 0 24px 48px rgba(6, 10, 34, 0.55);
+  position: relative;
+}
+
+.photon-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.photon-title {
+  margin: 0;
+  font-family: 'Audiowide', 'Orbitron', sans-serif;
+  font-size: clamp(1.3rem, 2vw, 1.5rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.photon-close-button {
+  appearance: none;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  width: clamp(2.1rem, 4vw, 2.4rem);
+  height: clamp(2.1rem, 4vw, 2.4rem);
+  border-radius: 999px;
+  font-size: 1.45rem;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.photon-close-button:hover,
+.photon-close-button:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.photon-close-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.3);
+  outline-offset: 3px;
+}
+
+.photon-stage {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 30%, rgba(42, 54, 96, 0.6), rgba(6, 10, 28, 0.95));
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  transition: box-shadow 0.25s ease;
+  touch-action: manipulation;
+}
+
+.photon-stage--blue {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 0 32px rgba(86, 166, 255, 0.32);
+}
+
+.photon-stage--red {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 0 32px rgba(255, 107, 141, 0.28);
+}
+
+.photon-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.photon-hud {
+  position: absolute;
+  top: clamp(0.7rem, 2vw, 1.2rem);
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(6, 10, 24, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  font-variant-numeric: tabular-nums;
+}
+
+.photon-hud__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.photon-hud__value {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.photon-hint {
+  position: absolute;
+  bottom: clamp(1rem, 2.5vw, 1.6rem);
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  font-size: 0.92rem;
+  text-align: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(8, 12, 32, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+  opacity: 0.82;
+}
+
+.photon-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(4, 6, 16, 0.7);
+  backdrop-filter: blur(6px);
+  padding: 1.6rem;
+  text-align: center;
+}
+
+.photon-overlay[hidden] {
+  display: none;
+}
+
+.photon-overlay__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: clamp(1.2rem, 3vw, 1.6rem);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(10, 14, 32, 0.82);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.photon-overlay__message {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.4;
+}
+
+.photon-overlay__button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg, #56a6ff, #ff6b8d);
+  color: #05070c;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.photon-overlay__button:hover,
+.photon-overlay__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 32px rgba(86, 166, 255, 0.4);
+}
+
+.photon-overlay__button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 3px;
+}
+
+.option-card--photon {
+  gap: 1rem;
+}
+
+.photon-launch-button {
+  align-self: flex-start;
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg, #56a6ff, #ff6b8d);
+  color: #05070c;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.photon-launch-button:hover,
+.photon-launch-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 32px rgba(86, 166, 255, 0.35);
+  filter: brightness(1.05);
+}
+
+.photon-launch-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 3px;
+}
+
+@media (max-width: 520px) {
+  .photon-window {
+    border-radius: 20px;
+    padding: clamp(1rem, 4vw, 1.4rem);
+  }
+
+  .photon-stage {
+    border-radius: 18px;
+  }
+
+  .photon-overlay__panel {
+    border-radius: 18px;
+  }
 }
 
 .arcade-header__brand:hover,


### PR DESCRIPTION
## Summary
- add a dedicated Photon mini-game page with canvas, HUD, and overlay
- implement the PhotonGame loop with color toggling, score tracking, and callbacks wired from app.js
- style the Photon experience and expose it from the Options menu

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d943c87f1c832ebf2609c6cb570b45