### PR TITLE
Refine Photon mini-game layout for widescreen displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,6 +387,10 @@
     <section id="photon" class="page page--photon" aria-label="Photon" hidden>
       <header class="photon-topbar">
         <h2 class="photon-title">Photon</h2>
+        <div class="photon-hud" aria-live="polite">
+          <span class="photon-hud__label">Score</span>
+          <span class="photon-hud__value" id="photonScoreValue">0</span>
+        </div>
         <button
           class="photon-close-button"
           id="photonCloseButton"
@@ -399,10 +403,6 @@
       <div class="photon-content">
         <div class="photon-stage" id="photonStage" role="application" aria-label="Zone de jeu Photon">
           <canvas class="photon-canvas" id="photonCanvas" width="360" height="640"></canvas>
-          <div class="photon-hud" aria-live="polite">
-            <span class="photon-hud__label">Score</span>
-            <span class="photon-hud__value" id="photonScoreValue">0</span>
-          </div>
           <p class="photon-hint">Cliquez ou touchez pour inverser la couleur du halo.</p>
           <div class="photon-overlay" id="photonOverlay" hidden>
             <div class="photon-overlay__panel" role="dialog" aria-modal="true" aria-labelledby="photonOverlayMessage">

--- a/scripts/photon.js
+++ b/scripts/photon.js
@@ -63,13 +63,13 @@
     getBarWidth() {
       const width = this.viewportWidth || 0;
       if (!width) return 0;
-      return clamp(width * 0.42, 120, 220);
+      return clamp(width * 0.78, 200, 1100);
     }
 
     getBarHeight() {
       const height = this.viewportHeight || 0;
       if (!height) return 0;
-      return clamp(height * 0.14, 70, 110);
+      return clamp(height * 0.08, 42, 80);
     }
 
     getBarSpeed() {
@@ -81,7 +81,7 @@
     getHaloHeight() {
       const height = this.viewportHeight || 0;
       if (!height) return 140;
-      return clamp(height * 0.22, 110, 180);
+      return clamp(height * 0.12, 60, 100);
     }
 
     resize() {

--- a/styles/main.css
+++ b/styles/main.css
@@ -607,7 +607,7 @@ main {
 }
 
 .page--photon {
-  --photon-topbar-height: clamp(3.2rem, 10vh, 5rem);
+  --photon-topbar-height: clamp(1.8rem, 6vh, 3rem);
   --photon-stage-padding: clamp(0.4rem, 2vw, 1.4rem);
   display: none;
   width: 100%;
@@ -672,12 +672,13 @@ main {
 
 
 .photon-topbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, auto) 1fr minmax(0, auto);
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-items: center;
+  gap: clamp(0.4rem, 1.5vw, 1.2rem);
   min-height: var(--photon-topbar-height);
-  padding: clamp(0.8rem, 2vw, 1.4rem) clamp(1rem, 3vw, 2rem);
+  padding: clamp(0.45rem, 1.4vw, 0.9rem) clamp(0.8rem, 2.4vw, 1.6rem);
   width: 100%;
   background: linear-gradient(140deg, rgba(20, 28, 56, 0.88), rgba(6, 10, 26, 0.9));
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
@@ -699,11 +700,11 @@ main {
 .photon-title {
   margin: 0;
   font-family: 'Audiowide', 'Orbitron', sans-serif;
-  font-size: clamp(1.3rem, 2vw, 1.5rem);
+  font-size: clamp(1.2rem, 1.8vw, 1.4rem);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  flex: 1;
-  text-align: center;
+  justify-self: start;
+  text-align: left;
 }
 
 .photon-close-button {
@@ -720,6 +721,7 @@ main {
   display: grid;
   place-items: center;
   transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  justify-self: end;
 }
 
 .photon-close-button:hover,
@@ -735,16 +737,22 @@ main {
 }
 
 .photon-stage {
+  --photon-stage-aspect-width: 9;
+  --photon-stage-aspect-height: 16;
   position: relative;
   width: min(
     92vw,
-    calc((100vh - var(--photon-topbar-height) - (var(--photon-stage-padding) * 2)) * 9 / 16)
+    calc(
+      (100vh - var(--photon-topbar-height) - (var(--photon-stage-padding) * 2))
+        * var(--photon-stage-aspect-width)
+        / var(--photon-stage-aspect-height)
+    )
   );
   height: min(
-    calc(92vw * 16 / 9),
+    calc(92vw * var(--photon-stage-aspect-height) / var(--photon-stage-aspect-width)),
     calc(100vh - var(--photon-topbar-height) - (var(--photon-stage-padding) * 2))
   );
-  aspect-ratio: 9 / 16;
+  aspect-ratio: calc(var(--photon-stage-aspect-width) / var(--photon-stage-aspect-height));
   border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   overflow: hidden;
@@ -753,6 +761,19 @@ main {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   transition: box-shadow 0.25s ease;
   touch-action: manipulation;
+}
+
+.photon-topbar .photon-hud {
+  display: inline-flex;
+  align-items: baseline;
+  gap: clamp(0.28rem, 1vw, 0.6rem);
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(6, 10, 24, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  font-variant-numeric: tabular-nums;
+  justify-self: center;
 }
 
 .photon-stage--blue {
@@ -769,22 +790,6 @@ main {
   width: 100%;
   height: 100%;
   display: block;
-}
-
-.photon-hud {
-  position: absolute;
-  top: clamp(0.7rem, 2vw, 1.2rem);
-  left: 50%;
-  transform: translateX(-50%);
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.4rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(6, 10, 24, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(8px);
-  font-variant-numeric: tabular-nums;
 }
 
 .photon-hud__label {
@@ -813,6 +818,13 @@ main {
   border: 1px solid rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(6px);
   opacity: 0.82;
+}
+
+@media (min-aspect-ratio: 16 / 9) {
+  .photon-stage {
+    --photon-stage-aspect-width: 81;
+    --photon-stage-aspect-height: 32;
+  }
 }
 
 .photon-overlay {


### PR DESCRIPTION
## Summary
- widen the Photon stage on widescreen viewports and adjust its responsive aspect ratio
- move the score HUD into the Photon header while slimming the top bar styling
- stretch Photon bars into longer beams and halve the halo height for the new layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d951930a10832e81888b4ef6905793