### PR TITLE
Refactor Photon mini-game settings into config

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1121,6 +1121,51 @@ const GAME_CONFIG = {
           bonusTicketPlural: 'tickets Mach3'
         }
       }
+    },
+    photon: {
+      colors: {
+        blue: {
+          bar: '#56a6ff',
+          barEdge: '#9ed2ff',
+          haloInner: 'rgba(86, 166, 255, 0.88)',
+          haloMid: 'rgba(86, 166, 255, 0.4)',
+          haloOuter: 'rgba(86, 166, 255, 0.08)'
+        },
+        red: {
+          bar: '#ff6b8d',
+          barEdge: '#ffc2d1',
+          haloInner: 'rgba(255, 107, 141, 0.9)',
+          haloMid: 'rgba(255, 107, 141, 0.42)',
+          haloOuter: 'rgba(255, 107, 141, 0.08)'
+        }
+      },
+      colorOrder: ['blue', 'red'],
+      bars: {
+        desiredCount: 3,
+        spawnGap: 90
+      },
+      geometry: {
+        barWidthRatio: 0.78,
+        barWidthMin: 200,
+        barWidthMax: 1100,
+        barHeightRatio: 0.08,
+        barHeightMin: 42,
+        barHeightMax: 80,
+        haloHeightRatio: 0.12,
+        haloHeightMin: 60,
+        haloHeightMax: 100
+      },
+      speed: {
+        baseRatio: 0.78,
+        min: 180,
+        max: 320,
+        initialReduction: 0.3,
+        ramp: {
+          intervalSeconds: 10,
+          increment: 0.01,
+          maxBonus: 0.5
+        }
+      }
     }
   },
 

--- a/index.html
+++ b/index.html
@@ -403,7 +403,6 @@
       <div class="photon-content">
         <div class="photon-stage" id="photonStage" role="application" aria-label="Zone de jeu Photon">
           <canvas class="photon-canvas" id="photonCanvas" width="360" height="640"></canvas>
-          <p class="photon-hint">Cliquez ou touchez pour inverser la couleur du halo.</p>
           <div class="photon-overlay" id="photonOverlay" hidden>
             <div class="photon-overlay__panel" role="dialog" aria-modal="true" aria-labelledby="photonOverlayMessage">
               <p class="photon-overlay__message" id="photonOverlayMessage">Prêt à synchroniser les photons ?</p>


### PR DESCRIPTION
## Summary
- move the Photon mini-game colour, geometry, and pacing parameters into the shared configuration
- update the Photon runtime to read from config, support configurable colour order, and add the new gradual speed ramp
- remove the in-game hint text from the Photon stage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9559c8e98832ebcbc06c7e3e7953a