### PR TITLE
Move Options welcome copy into config constants

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -572,6 +572,43 @@ function createAtomScaleTrophies() {
 
 const GAME_CONFIG = {
   /**
+   * Textes affichés dans l'interface utilisateur.
+   * Centralisés ici pour faciliter leur édition sans toucher au HTML.
+   */
+  uiText: {
+    options: {
+      welcomeCard: {
+        title: 'Bienvenue',
+        introParagraphs: [
+          "Bienvenue dans Atom to Univers, commencez en cliquant pour gagner des Atomes (APC Atoms Par Clic), achetez des améliorations dans le magasin et automatisez la récolte (APS Atoms Par Seconde). Débloquez des minis jeux au fur et à mesure de votre progression. L’objectif est d’accumuler le plus possible d’Atomes pour fabriquer un Univers."
+        ],
+        unlockedDetails: [
+          {
+            label: 'Mini Jeu Particules :',
+            description:
+              'Collisionnez les particules élémentaires afin de gagner des tickets de tirage pour la Gacha, et des crédits pour le mini jeu Mach3.'
+          },
+          {
+            label: 'Gacha :',
+            description:
+              'Grâce à vos tickets gagnez des Atomes du tableau périodique des éléments, leurs collections vous octroieront des bonus de APS et APC notamment.'
+          },
+          {
+            label: 'Mini jeu Mach3 :',
+            description:
+              "C’est un jeu de Match 3, alignez le Cuivre, le Bronze, l’Argent, l’Or et le Carbone (Diamant) le plus vite possible avant que le timer atteigne 0. Plus votre score sera grand, plus grand sera votre bonus de production d’APS."
+          },
+          {
+            label: 'Mini jeu Photon :',
+            description:
+              'Incarnez un Photon qui change d’état afin de passer entre des mailles, ou dans des trous le plus longtemps possible. Ajoutera un bonus plus tard.'
+          }
+        ]
+      }
+    }
+  },
+
+  /**
    * Paramètres du système de grands nombres et des layers.
    * - layer1Threshold : passage automatique au layer 1 lorsque l'exposant dépasse ce seuil.
    * - layer1Downshift : retour au layer 0 quand la valeur redescend sous ce niveau.

--- a/index.html
+++ b/index.html
@@ -488,6 +488,11 @@
     <section id="options" class="page" aria-labelledby="options-title">
       <h2 id="options-title">Options</h2>
       <div class="options-grid">
+        <div class="option-card option-card--intro">
+          <h3 id="optionsWelcomeTitle"></h3>
+          <div id="optionsWelcomeIntro" class="option-welcome-intro"></div>
+          <div id="optionsArcadeDetails" class="option-note" hidden aria-hidden="true"></div>
+        </div>
         <div class="option-card">
           <h3>Musique</h3>
           <div class="option-row">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,4 +1,13 @@
 const APP_DATA = typeof globalThis !== 'undefined' && globalThis.APP_DATA ? globalThis.APP_DATA : {};
+const GLOBAL_CONFIG =
+  typeof globalThis !== 'undefined' && globalThis.GAME_CONFIG ? globalThis.GAME_CONFIG : {};
+const OPTIONS_WELCOME_CARD =
+  GLOBAL_CONFIG
+  && GLOBAL_CONFIG.uiText
+  && GLOBAL_CONFIG.uiText.options
+  && GLOBAL_CONFIG.uiText.options.welcomeCard
+    ? GLOBAL_CONFIG.uiText.options.welcomeCard
+    : null;
 
 const ATOM_SCALE_TROPHY_DATA = Array.isArray(APP_DATA.ATOM_SCALE_TROPHY_DATA)
   ? APP_DATA.ATOM_SCALE_TROPHY_DATA
@@ -1395,6 +1404,7 @@ function unlockTrophy(def) {
   recalcProduction();
   updateGoalsUI();
   updateBigBangVisibility();
+  updateOptionsIntroDetails();
   updateBrickSkinOption();
   updateBrandPortalState({ animate: def.id === ARCADE_TROPHY_ID });
   updatePrimaryNavigationLocks();
@@ -1519,6 +1529,9 @@ const elements = {
   musicTrackSelect: document.getElementById('musicTrackSelect'),
   musicTrackStatus: document.getElementById('musicTrackStatus'),
   musicVolumeSlider: document.getElementById('musicVolumeSlider'),
+  optionsWelcomeTitle: document.getElementById('optionsWelcomeTitle'),
+  optionsWelcomeIntro: document.getElementById('optionsWelcomeIntro'),
+  optionsArcadeDetails: document.getElementById('optionsArcadeDetails'),
   brickSkinOptionCard: document.getElementById('brickSkinOptionCard'),
   brickSkinSelect: document.getElementById('brickSkinSelect'),
   brickSkinStatus: document.getElementById('brickSkinStatus'),
@@ -1561,6 +1574,67 @@ const elements = {
   devkitToggleGacha: document.getElementById('devkitToggleGacha')
 };
 
+function renderOptionsWelcomeContent() {
+  const copy = OPTIONS_WELCOME_CARD;
+  if (elements.optionsWelcomeTitle) {
+    const titleText =
+      copy && typeof copy.title === 'string' && copy.title.trim().length
+        ? copy.title
+        : 'Bienvenue';
+    elements.optionsWelcomeTitle.textContent = titleText;
+  }
+  if (elements.optionsWelcomeIntro) {
+    const container = elements.optionsWelcomeIntro;
+    container.innerHTML = '';
+    const paragraphs =
+      copy && Array.isArray(copy.introParagraphs)
+        ? copy.introParagraphs
+        : copy && typeof copy.intro === 'string'
+          ? [copy.intro]
+          : [];
+    paragraphs.forEach(paragraph => {
+      if (typeof paragraph !== 'string' || !paragraph.trim()) {
+        return;
+      }
+      const node = document.createElement('p');
+      node.textContent = paragraph;
+      container.appendChild(node);
+    });
+  }
+  if (elements.optionsArcadeDetails) {
+    const container = elements.optionsArcadeDetails;
+    container.innerHTML = '';
+    const details =
+      copy && Array.isArray(copy.unlockedDetails)
+        ? copy.unlockedDetails
+        : [];
+    details.forEach(detail => {
+      if (!detail || typeof detail !== 'object') {
+        return;
+      }
+      const label = typeof detail.label === 'string' ? detail.label : null;
+      const description = typeof detail.description === 'string' ? detail.description : null;
+      if (!label && !description) {
+        return;
+      }
+      const paragraph = document.createElement('p');
+      if (label) {
+        const strong = document.createElement('strong');
+        strong.textContent = label;
+        paragraph.appendChild(strong);
+        if (description) {
+          paragraph.appendChild(document.createTextNode(` ${description}`));
+        }
+      } else {
+        paragraph.textContent = description;
+      }
+      container.appendChild(paragraph);
+    });
+  }
+}
+
+renderOptionsWelcomeContent();
+
 function updateBrickSkinOption() {
   if (!elements.brickSkinOptionCard || !elements.brickSkinSelect) {
     return;
@@ -1578,6 +1652,15 @@ function updateBrickSkinOption() {
       ? 'Choisissez l’apparence des briques de Particules.'
       : 'Débloquez le trophée « Ruée vers le million » pour personnaliser vos briques.';
   }
+}
+
+function updateOptionsIntroDetails() {
+  if (!elements.optionsArcadeDetails) {
+    return;
+  }
+  const unlocked = isArcadeUnlocked();
+  elements.optionsArcadeDetails.hidden = !unlocked;
+  elements.optionsArcadeDetails.setAttribute('aria-hidden', unlocked ? 'false' : 'true');
 }
 
 function updatePhotonStageColor(color) {
@@ -7029,6 +7112,7 @@ function updateUI() {
   updatePrimaryNavigationLocks();
   updatePageUnlockUI();
   updateBigBangVisibility();
+  updateOptionsIntroDetails();
   updateBrickSkinOption();
   updateBrandPortalState();
   updateMetauxCreditsUI();


### PR DESCRIPTION
## Summary
- centralize the Options welcome card text inside `GAME_CONFIG` so it can be edited from a single place
- render the Options welcome content from the config and preserve the trophy-gated arcade details logic
- swap the static HTML paragraphs for script-populated placeholders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f83059e8832ebd43836346885ea2