### PR TITLE
Consolidate Pastels brick skin selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,7 @@
               <option value="original">Original</option>
               <option value="metallic">Metallic</option>
               <option value="neon">Néon</option>
+              <option value="pastels">Pastels</option>
             </select>
           </div>
           <p class="option-note" id="brickSkinStatus">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -39,16 +39,20 @@ const MUSIC_FALLBACK_TRACKS = Array.isArray(APP_DATA.MUSIC_FALLBACK_TRACKS)
       ? [...APP_DATA.DEFAULT_MUSIC_FALLBACK_TRACKS]
       : [];
 
-const BRICK_SKIN_CHOICES = Object.freeze(['original', 'metallic', 'neon']);
+const BRICK_SKIN_CHOICES = Object.freeze(['original', 'metallic', 'neon', 'pastels']);
 
 const BRICK_SKIN_TOAST_MESSAGES = Object.freeze({
   original: 'Skin original appliqué.',
   metallic: 'Skin Metallic appliqué.',
-  neon: 'Skin Néon appliqué.'
+  neon: 'Skin Néon appliqué.',
+  pastels: 'Skin Pastels appliqué.'
 });
 
 function normalizeBrickSkinSelection(rawValue) {
   const value = typeof rawValue === 'string' ? rawValue.trim().toLowerCase() : '';
+  if (value === 'pastels1' || value === 'pastels2') {
+    return 'pastels';
+  }
   if (BRICK_SKIN_CHOICES.includes(value)) {
     return value;
   }


### PR DESCRIPTION
## Summary
- collapse the Pastels brick skin into a single option and toast message in the options UI
- compose both Pastels sprite sheets into one skin and update rendering to pull frames from either source
- normalize legacy pastels1/pastels2 values to the consolidated skin

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da08151c88832e8d3113b7fce1ba0f