### PR TITLE
Fix pastel brick skin selection

### DIFF
--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -1851,6 +1851,9 @@ function normalizeParticulesBrickSkin(value) {
   if (!normalized || normalized === 'original' || normalized === 'default') {
     return null;
   }
+  if (normalized === 'pastels' || normalized === 'pastels1' || normalized === 'pastels2') {
+    return 'pastels';
+  }
   if (normalized === 'metallic' || normalized === 'neon') {
     return normalized;
   }


### PR DESCRIPTION
## Summary
- allow the gacha/arcade brick skin preference to accept the pastel variants by normalizing to the shared key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3c642944832e9c6208379726e4de