### PR TITLE
Utilize translation strings for dynamic UI text

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -41,11 +41,11 @@ const MUSIC_FALLBACK_TRACKS = Array.isArray(APP_DATA.MUSIC_FALLBACK_TRACKS)
 
 const BRICK_SKIN_CHOICES = Object.freeze(['original', 'metallic', 'neon', 'pastels']);
 
-const BRICK_SKIN_TOAST_MESSAGES = Object.freeze({
-  original: 'Skin original appliqué.',
-  metallic: 'Skin Metallic appliqué.',
-  neon: 'Skin Néon appliqué.',
-  pastels: 'Skin Pastels appliqué.'
+const BRICK_SKIN_TOAST_KEYS = Object.freeze({
+  original: 'scripts.app.brickSkins.applied.original',
+  metallic: 'scripts.app.brickSkins.applied.metallic',
+  neon: 'scripts.app.brickSkins.applied.neon',
+  pastels: 'scripts.app.brickSkins.applied.pastels'
 });
 
 function normalizeBrickSkinSelection(rawValue) {
@@ -2654,20 +2654,20 @@ function updateMusicSelectOptions() {
   if (!tracks.length) {
     const option = document.createElement('option');
     option.value = '';
-    option.textContent = 'Aucune piste disponible';
+    option.textContent = t('scripts.app.music.noneAvailable');
     select.appendChild(option);
     select.disabled = true;
     return;
   }
   const noneOption = document.createElement('option');
   noneOption.value = '';
-  noneOption.textContent = 'Rien (aucune musique)';
+  noneOption.textContent = t('scripts.app.music.noneOption');
   select.appendChild(noneOption);
   tracks.forEach(track => {
     const option = document.createElement('option');
     option.value = track.id;
     option.textContent = track.placeholder
-      ? `${track.displayName} (fichier manquant)`
+      ? t('scripts.app.music.missingDisplay', { name: track.displayName })
       : track.displayName;
     option.dataset.placeholder = track.placeholder ? 'true' : 'false';
     select.appendChild(option);
@@ -2697,31 +2697,31 @@ function updateMusicStatus() {
   }
   const tracks = musicPlayer.getTracks();
   if (!tracks.length) {
-    status.textContent = 'Ajoutez vos fichiers audio dans Assets/Music pour activer la musique.';
+    status.textContent = t('scripts.app.music.addFilesHint');
     return;
   }
   const current = musicPlayer.getCurrentTrack();
   if (!current) {
     if (gameState.musicEnabled === false) {
-      status.textContent = 'Musique désactivée.';
+      status.textContent = t('scripts.app.music.disabled');
     } else {
-      status.textContent = 'Sélectionnez une piste pour lancer la musique.';
+      status.textContent = t('scripts.app.music.selectTrack');
     }
     return;
   }
   const playbackState = musicPlayer.getPlaybackState();
-  let message = `Lecture en boucle : ${current.displayName}`;
+  let message = t('scripts.app.music.looping', { track: current.displayName });
   if (current.placeholder) {
-    message += ' (fichier manquant)';
+    message += t('scripts.app.music.missingSuffix');
   }
   if (playbackState === 'unsupported') {
-    message += '. Lecture audio indisponible sur cet appareil.';
+    message += t('scripts.app.music.unsupportedSuffix');
   } else if (playbackState === 'error') {
-    message += '. Impossible de lire le fichier audio.';
+    message += t('scripts.app.music.errorSuffix');
   } else if (musicPlayer.isAwaitingUserGesture()) {
-    message += '. La musique démarre après votre première interaction.';
+    message += t('scripts.app.music.awaitingInteractionSuffix');
   } else if (playbackState === 'paused' || playbackState === 'idle') {
-    message += '. Lecture en pause.';
+    message += t('scripts.app.music.pausedSuffix');
   }
   status.textContent = message;
 }
@@ -2738,7 +2738,7 @@ function updateMusicVolumeControl() {
   slider.value = String(clamped);
   slider.setAttribute('aria-valuenow', String(clamped));
   slider.setAttribute('aria-valuetext', `${clamped}%`);
-  slider.title = `Volume musique : ${clamped}%`;
+  slider.title = t('scripts.app.music.volumeLabel', { value: clamped });
   const playbackState = musicPlayer.getPlaybackState();
   slider.disabled = playbackState === 'unsupported';
 }
@@ -3460,10 +3460,10 @@ function renderPeriodicTable() {
   if (!periodicElements.length) {
     const placeholder = document.createElement('p');
     placeholder.className = 'periodic-placeholder';
-    placeholder.textContent = 'Le tableau périodique sera bientôt disponible.';
+    placeholder.textContent = t('scripts.app.table.placeholder');
     elements.periodicTable.appendChild(placeholder);
     if (elements.collectionProgress) {
-      elements.collectionProgress.textContent = 'Collection en préparation';
+      elements.collectionProgress.textContent = t('scripts.app.collection.pending');
     }
     selectPeriodicElement(null);
     return;
@@ -3563,7 +3563,7 @@ function updateCollectionDisplay() {
     if (total > 0) {
       elements.collectionProgress.textContent = `Collection\u00a0: ${ownedCount} / ${total} éléments`;
     } else {
-      elements.collectionProgress.textContent = 'Collection en préparation';
+      elements.collectionProgress.textContent = t('scripts.app.collection.pending');
     }
   }
 
@@ -3577,7 +3577,7 @@ function updateCollectionDisplay() {
           : ratio.toFixed(2).replace('.', ',');
       elements.gachaOwnedSummary.textContent = `Collection\u00a0: ${ownedCount} / ${total} éléments (${formatted}\u00a0%)`;
     } else {
-      elements.gachaOwnedSummary.textContent = 'Collection en préparation';
+      elements.gachaOwnedSummary.textContent = t('scripts.app.collection.pending');
     }
   }
 
@@ -6818,7 +6818,7 @@ function updateShopAffordability() {
 
       if (capReached) {
         entry.quantityLabel.textContent = `x${baseQuantity}`;
-        entry.price.textContent = 'Limite atteinte';
+        entry.price.textContent = t('scripts.app.shop.limitReached');
         entry.button.disabled = true;
         entry.button.classList.remove('is-ready');
         const ariaLabel = `${def.name} a atteint son niveau maximum`;
@@ -6980,7 +6980,7 @@ function updateMilestone() {
       return;
     }
   }
-  elements.nextMilestone.textContent = 'Continuez à explorer des ordres de grandeur toujours plus vastes !';
+  elements.nextMilestone.textContent = t('scripts.app.shop.milestoneHint');
 }
 
 function updateGoalsUI() {
@@ -7216,8 +7216,8 @@ if (elements.brickSkinSelect) {
     }
     updateBrickSkinOption();
     saveGame();
-    const message = BRICK_SKIN_TOAST_MESSAGES[selection] || 'Skin mis à jour.';
-    showToast(message);
+    const messageKey = BRICK_SKIN_TOAST_KEYS[selection] || 'scripts.app.brickSkins.applied.generic';
+    showToast(t(messageKey));
   });
 }
 
@@ -7226,12 +7226,12 @@ if (elements.musicTrackSelect) {
     const selectedId = event.target.value;
     if (!selectedId) {
       musicPlayer.stop();
-      showToast('Musique coupée');
+      showToast(t('scripts.app.music.muted'));
       return;
     }
     const success = musicPlayer.playTrackById(selectedId);
     if (!success) {
-      showToast('Piste introuvable');
+      showToast(t('scripts.app.music.missing'));
       updateMusicStatus();
       return;
     }

--- a/scripts/i18n/en.json
+++ b/scripts/i18n/en.json
@@ -470,6 +470,19 @@
       },
       "themeUpdated": "Theme updated",
       "music": {
+        "noneAvailable": "No tracks available",
+        "noneOption": "None (no music)",
+        "addFilesHint": "Add your audio files to Assets/Music to enable music.",
+        "disabled": "Music disabled.",
+        "selectTrack": "Select a track to start the music.",
+        "missingDisplay": "{{name}} (file missing)",
+        "missingSuffix": " (file missing)",
+        "unsupportedSuffix": ". Audio playback unavailable on this device.",
+        "errorSuffix": ". Unable to play the audio file.",
+        "awaitingInteractionSuffix": ". Music will start after your first interaction.",
+        "pausedSuffix": ". Playback paused.",
+        "looping": "Looping: {{track}}",
+        "volumeLabel": "Music volume: {{value}}%",
         "muted": "Music muted",
         "missing": "Track not found",
         "fileMissing": "The file for this track is missing."
@@ -486,6 +499,12 @@
       },
       "fusion": {
         "prompt": "Select a recipe to attempt your first fusion."
+      },
+      "table": {
+        "placeholder": "The periodic table will be available soon."
+      },
+      "collection": {
+        "pending": "Collection in progress"
       },
       "errors": {
         "save": "Save error",
@@ -530,6 +549,87 @@
         "friday": "+Quantum Myth",
         "wednesday": "+Unreal",
         "saturday": "+Unreal"
+      },
+      "rarityProgress": {
+        "unavailable": "Rarities unavailable",
+        "empty": "No elements",
+        "summary": "{{owned}} / {{total}} elements"
+      },
+      "fusion": {
+        "successChance": "Success chance: {{chance}}",
+        "availabilityInitial": "Available: 0",
+        "tryButton": "Attempt fusion",
+        "tryButtonAria": "Attempt {{name}} fusion",
+        "checking": "Checking ingredients…",
+        "stats": "Attempts: {{attempts}} · Successes: {{successes}}",
+        "successBonus": "Reward per success: {{bonus}}",
+        "noBonus": "No bonus defined",
+        "totalBonus": "Total bonus: {{bonus}}",
+        "apcBonus": "+{{value}} APC",
+        "apsBonus": "+{{value}} APS",
+        "apcTotal": "+{{value}} APC total",
+        "apsTotal": "+{{value}} APS total",
+        "availabilityProgress": "Available: {{available}} / {{required}}",
+        "statusReady": "Ingredients available",
+        "statusMissing": "Insufficient resources",
+        "logMissingResources": "You don't have enough resources for this fusion.",
+        "toastMissingResources": "Not enough resources for this fusion.",
+        "noRewardSummary": "No bonus.",
+        "logSuccess": "{{name}} fusion succeeded! Reward earned: {{reward}}",
+        "toastSuccess": "Fusion succeeded!",
+        "logFailure": "{{name}} fusion failed. Ingredients were consumed.",
+        "toastFailure": "Fusion failed."
+      },
+      "results": {
+        "unavailable": "Synthesis unavailable for now.",
+        "unknownRarity": "Unknown rarity",
+        "unknownElement": "Unknown element",
+        "newTag": "NEW!",
+        "duplicateTag": "Already owned",
+        "drawLabel": "Draw x{{count}}",
+        "drawSingle": "Draw x1",
+        "newSingle": "1 new element",
+        "newPlural": "{{count}} new elements",
+        "duplicateSingle": "1 duplicate",
+        "duplicatePlural": "{{count}} duplicates"
+      },
+      "tickets": {
+        "single": "ticket",
+        "plural": "tickets",
+        "bonusSingle": "Mach3 ticket",
+        "bonusPlural": "Mach3 tickets"
+      },
+      "controls": {
+        "modeSingle": "Draw x1",
+        "modeMulti": "Draw x{{count}}",
+        "toggleModeAria": "Toggle draw mode (current: {{mode}})",
+        "toggleModeTitle": "Current mode: {{mode}}",
+        "drawMulti": "cosmic draw x{{count}}",
+        "drawSingleLabel": "cosmic draw",
+        "drawInProgress": "Cosmic draw in progress",
+        "drawFree": "Trigger a {{draw}} (free)",
+        "drawPaid": "Trigger a {{draw}}",
+        "drawLocked": "Not enough tickets for a {{draw}}",
+        "drawTitle": "{{label}} ({{cost}})"
+      },
+      "arcade": {
+        "reward": "+{{reward}} thanks to Particules!",
+        "bonus": "+{{reward}}!"
+      },
+      "errors": {
+        "notEnoughTickets": "Not enough draw tickets (required: {{cost}}).",
+        "noElements": "No elements available in the synthesis chambers.",
+        "instableFlux": "Unstable flux, unable to materialize an element."
+      },
+      "toast": {
+        "newSingle": "New element obtained: {{name}}!",
+        "duplicateSingle": "{{name}} rejoins your collection.",
+        "newMultiple": "{{count}} new elements discovered!",
+        "duplicateWithRarity": "{{name}} ({{rarity}}) rejoins your collection."
+      },
+      "ticketStar": {
+        "single": "Draw ticket obtained!",
+        "multiple": "+{{count}} draw tickets!"
       }
     },
     "info": {
@@ -553,6 +653,36 @@
         "requireUnique": "at least {{count}} {{unit}}",
         "requireFull": "complete collection required",
         "rarityAmplify": "Amplifies {{rarity}}: {{effects}}"
+      },
+      "collections": {
+        "complete": "Family complete",
+        "inProgress": "Family in progress"
+      },
+      "sections": {
+        "activeBoosts": "Active boosts",
+        "specialEffects": "Special effects",
+        "inactiveBonuses": "Inactive bonuses"
+      },
+      "shop": {
+        "noneAvailable": "No upgrades available.",
+        "level": "Level {{level}}",
+        "notPurchased": "Not purchased",
+        "bonus": {
+          "apcFlat": "APC +",
+          "apsFlat": "APS +",
+          "apcMult": "APC ×",
+          "apsMult": "APS ×"
+        },
+        "pendingThreshold": "Bonus awaiting threshold.",
+        "locked": "Purchase this upgrade to activate its effects."
+      }
+    },
+    "metaux": {
+      "timer": {
+        "max": "Max {{value}}"
+      },
+      "session": {
+        "start": "New session: chain those alloys!"
       }
     }
   }

--- a/scripts/i18n/fr.json
+++ b/scripts/i18n/fr.json
@@ -470,6 +470,19 @@
       },
       "themeUpdated": "Thème mis à jour",
       "music": {
+        "noneAvailable": "Aucune piste disponible",
+        "noneOption": "Rien (aucune musique)",
+        "addFilesHint": "Ajoutez vos fichiers audio dans Assets/Music pour activer la musique.",
+        "disabled": "Musique désactivée.",
+        "selectTrack": "Sélectionnez une piste pour lancer la musique.",
+        "missingDisplay": "{{name}} (fichier manquant)",
+        "missingSuffix": " (fichier manquant)",
+        "unsupportedSuffix": ". Lecture audio indisponible sur cet appareil.",
+        "errorSuffix": ". Impossible de lire le fichier audio.",
+        "awaitingInteractionSuffix": ". La musique démarre après votre première interaction.",
+        "pausedSuffix": ". Lecture en pause.",
+        "looping": "Lecture en boucle : {{track}}",
+        "volumeLabel": "Volume musique : {{value}}%",
         "muted": "Musique coupée",
         "missing": "Piste introuvable",
         "fileMissing": "Le fichier de cette piste est manquant."
@@ -486,6 +499,12 @@
       },
       "fusion": {
         "prompt": "Sélectionnez une recette pour tenter votre première fusion."
+      },
+      "table": {
+        "placeholder": "Le tableau périodique sera bientôt disponible."
+      },
+      "collection": {
+        "pending": "Collection en préparation"
       },
       "errors": {
         "save": "Erreur de sauvegarde",
@@ -530,6 +549,87 @@
         "friday": "+Mythe Quantique",
         "wednesday": "+Iréel",
         "saturday": "+Iréel"
+      },
+      "rarityProgress": {
+        "unavailable": "Raretés indisponibles",
+        "empty": "Aucun élément",
+        "summary": "{{owned}} / {{total}} éléments"
+      },
+      "fusion": {
+        "successChance": "Chance de réussite : {{chance}}",
+        "availabilityInitial": "Disponible : 0",
+        "tryButton": "Tenter la fusion",
+        "tryButtonAria": "Tenter la fusion {{name}}",
+        "checking": "Vérification des ingrédients…",
+        "stats": "Tentatives : {{attempts}} · Succès : {{successes}}",
+        "successBonus": "Bonus par réussite : {{bonus}}",
+        "noBonus": "Aucun bonus défini",
+        "totalBonus": "Bonus cumulé : {{bonus}}",
+        "apcBonus": "+{{value}} APC",
+        "apsBonus": "+{{value}} APS",
+        "apcTotal": "+{{value}} APC cumulés",
+        "apsTotal": "+{{value}} APS cumulés",
+        "availabilityProgress": "Disponible : {{available}} / {{required}}",
+        "statusReady": "Ingrédients disponibles",
+        "statusMissing": "Ressources insuffisantes",
+        "logMissingResources": "Vous n’avez pas assez de ressources pour cette fusion.",
+        "toastMissingResources": "Ressources insuffisantes pour cette fusion.",
+        "noRewardSummary": "Aucun bonus.",
+        "logSuccess": "Fusion {{name}} réussie ! Bonus obtenu : {{reward}}",
+        "toastSuccess": "Fusion réussie !",
+        "logFailure": "La fusion {{name}} a échoué. Les éléments ont été consommés.",
+        "toastFailure": "Fusion échouée."
+      },
+      "results": {
+        "unavailable": "Synthèse indisponible pour le moment.",
+        "unknownRarity": "Rareté inconnue",
+        "unknownElement": "Élément inconnu",
+        "newTag": "NOUVEAU !",
+        "duplicateTag": "Déjà possédé",
+        "drawLabel": "Tirage x{{count}}",
+        "drawSingle": "Tirage x1",
+        "newSingle": "1 nouvel élément",
+        "newPlural": "{{count}} nouveaux éléments",
+        "duplicateSingle": "1 doublon",
+        "duplicatePlural": "{{count}} doublons"
+      },
+      "tickets": {
+        "single": "ticket",
+        "plural": "tickets",
+        "bonusSingle": "ticket Mach3",
+        "bonusPlural": "tickets Mach3"
+      },
+      "controls": {
+        "modeSingle": "Tirage x1",
+        "modeMulti": "Tirage x{{count}}",
+        "toggleModeAria": "Basculer le mode de tirage (actuel\u00a0: {{mode}})",
+        "toggleModeTitle": "Mode actuel\u00a0: {{mode}}",
+        "drawMulti": "tirage cosmique x{{count}}",
+        "drawSingleLabel": "tirage cosmique",
+        "drawInProgress": "Tirage cosmique en cours",
+        "drawFree": "Déclencher un {{draw}} (gratuit)",
+        "drawPaid": "Déclencher un {{draw}}",
+        "drawLocked": "Tickets insuffisants pour un {{draw}}",
+        "drawTitle": "{{label}} ({{cost}})"
+      },
+      "arcade": {
+        "reward": "+{{reward}} grâce à Particules !",
+        "bonus": "+{{reward}} !"
+      },
+      "errors": {
+        "notEnoughTickets": "Pas assez de tickets de tirage (nécessaire\u00a0: {{cost}}).",
+        "noElements": "Aucun élément disponible dans les chambres de synthèse.",
+        "instableFlux": "Flux instable, impossible de matérialiser un élément."
+      },
+      "toast": {
+        "newSingle": "Nouvel élément obtenu : {{name}} !",
+        "duplicateSingle": "{{name}} rejoint à nouveau votre collection.",
+        "newMultiple": "{{count}} nouveaux éléments découverts !",
+        "duplicateWithRarity": "{{name}} ({{rarity}}) rejoint à nouveau votre collection."
+      },
+      "ticketStar": {
+        "single": "Ticket de tirage obtenu !",
+        "multiple": "+{{count}} tickets de tirage !"
       }
     },
     "info": {
@@ -553,6 +653,36 @@
         "requireUnique": "minimum {{count}} {{unit}}",
         "requireFull": "collection complète requise",
         "rarityAmplify": "Amplifie {{rarity}} : {{effects}}"
+      },
+      "collections": {
+        "complete": "Famille complète",
+        "inProgress": "Famille en cours"
+      },
+      "sections": {
+        "activeBoosts": "Boosts actifs",
+        "specialEffects": "Effets spéciaux",
+        "inactiveBonuses": "Bonus inactifs"
+      },
+      "shop": {
+        "noneAvailable": "Aucune amélioration disponible.",
+        "level": "Niveau {{level}}",
+        "notPurchased": "Non acheté",
+        "bonus": {
+          "apcFlat": "APC +",
+          "apsFlat": "APS +",
+          "apcMult": "APC ×",
+          "apsMult": "APS ×"
+        },
+        "pendingThreshold": "Bonus en attente de seuil.",
+        "locked": "Achetez cette amélioration pour activer ses effets."
+      }
+    },
+    "metaux": {
+      "timer": {
+        "max": "Max {{value}}"
+      },
+      "session": {
+        "start": "Nouvelle session : enchaînez les alliages !"
       }
     }
   }

--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -106,13 +106,13 @@ const BASE_GACHA_RARITY_ID_SET = new Set(BASE_GACHA_RARITIES.map(entry => entry.
 
 const WEEKDAY_KEYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
 
-const GACHA_FEATURED_LABELS_BY_DAY = Object.freeze({
-  monday: '+Singularité Minérale',
-  thursday: '+Singularité Minérale',
-  tuesday: '+Mythe Quantique',
-  friday: '+Mythe Quantique',
-  wednesday: '+Iréel',
-  saturday: '+Iréel'
+const GACHA_FEATURED_LABEL_KEYS_BY_DAY = Object.freeze({
+  monday: 'scripts.gacha.featured.monday',
+  thursday: 'scripts.gacha.featured.thursday',
+  tuesday: 'scripts.gacha.featured.tuesday',
+  friday: 'scripts.gacha.featured.friday',
+  wednesday: 'scripts.gacha.featured.wednesday',
+  saturday: 'scripts.gacha.featured.saturday'
 });
 
 function sanitizeWeeklyRarityWeights(rawWeights) {
@@ -213,7 +213,8 @@ function getGachaFeaturedLabelForDayKey(dayKey) {
   if (!dayKey) {
     return null;
   }
-  return GACHA_FEATURED_LABELS_BY_DAY[dayKey] ?? null;
+  const key = GACHA_FEATURED_LABEL_KEYS_BY_DAY[dayKey] ?? null;
+  return key ? t(key) : null;
 }
 
 function updateGachaFeaturedInfo(dayKey = WEEKDAY_KEYS[new Date().getDay()] ?? null) {
@@ -246,7 +247,7 @@ const INFO_BONUS_RARITIES = RARITY_IDS.length > 0
   : ['commun', 'essentiel', 'stellaire', 'singulier', 'mythique', 'irreel'];
 const INFO_BONUS_SUBTITLE = INFO_BONUS_RARITIES.length
   ? INFO_BONUS_RARITIES.map(id => RARITY_LABEL_MAP.get(id) || id).join(' · ')
-  : 'Raretés indisponibles';
+  : t('scripts.gacha.rarityProgress.unavailable');
 
 const rawTicketStarConfig = CONFIG.ticketStar && typeof CONFIG.ticketStar === 'object'
   ? CONFIG.ticketStar
@@ -1220,7 +1221,7 @@ function renderGachaRarityList() {
 
     const summary = document.createElement('p');
     summary.className = 'gacha-rarity__summary';
-    summary.textContent = 'Aucun élément';
+    summary.textContent = t('scripts.gacha.rarityProgress.empty');
 
     item.append(progress, summary);
     elements.gachaRarityList.appendChild(item);
@@ -1257,8 +1258,8 @@ function updateGachaRarityProgress() {
     const percent = total > 0 ? (owned / total) * 100 : 0;
     row.bar.style.width = `${percent}%`;
     row.summary.textContent = total > 0
-      ? `${owned} / ${total} éléments`
-      : 'Aucun élément';
+      ? t('scripts.gacha.rarityProgress.summary', { owned, total })
+      : t('scripts.gacha.rarityProgress.empty');
   });
 }
 
@@ -1356,7 +1357,9 @@ function buildFusionCard(definition) {
 
   const chance = document.createElement('p');
   chance.className = 'fusion-card__chance';
-  chance.textContent = `Chance de réussite : ${formatFusionChance(definition.successChance)}`;
+  chance.textContent = t('scripts.gacha.fusion.successChance', {
+    chance: formatFusionChance(definition.successChance)
+  });
 
   header.append(title, chance);
 
@@ -1391,7 +1394,7 @@ function buildFusionCard(definition) {
 
     const availability = document.createElement('span');
     availability.className = 'fusion-requirement__availability';
-    availability.textContent = 'Disponible : 0';
+    availability.textContent = t('scripts.gacha.fusion.availabilityInitial');
 
     item.append(symbol, name, count, availability);
     requirementList.appendChild(item);
@@ -1410,38 +1413,44 @@ function buildFusionCard(definition) {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'fusion-card__button';
-  button.textContent = 'Tenter la fusion';
-  button.setAttribute('aria-label', `Tenter la fusion ${definition.name}`);
+  button.textContent = t('scripts.gacha.fusion.tryButton');
+  button.setAttribute('aria-label', t('scripts.gacha.fusion.tryButtonAria', {
+    name: definition.name
+  }));
   button.addEventListener('click', () => {
     handleFusionAttempt(definition.id);
   });
 
   const status = document.createElement('span');
   status.className = 'fusion-card__feedback fusion-card__status';
-  status.textContent = 'Vérification des ingrédients…';
+  status.textContent = t('scripts.gacha.fusion.checking');
 
   actions.append(button, status);
 
   const stats = document.createElement('p');
   stats.className = 'fusion-card__stats';
-  stats.textContent = 'Tentatives : 0 · Succès : 0';
+  stats.textContent = t('scripts.gacha.fusion.stats', { attempts: 0, successes: 0 });
 
   const bonusParts = [];
   if (definition.rewards.apcFlat) {
-    bonusParts.push(`+${definition.rewards.apcFlat.toLocaleString('fr-FR')} APC`);
+    bonusParts.push(t('scripts.gacha.fusion.apcBonus', {
+      value: definition.rewards.apcFlat.toLocaleString('fr-FR')
+    }));
   }
   if (definition.rewards.apsFlat) {
-    bonusParts.push(`+${definition.rewards.apsFlat.toLocaleString('fr-FR')} APS`);
+    bonusParts.push(t('scripts.gacha.fusion.apsBonus', {
+      value: definition.rewards.apsFlat.toLocaleString('fr-FR')
+    }));
   }
   const bonus = document.createElement('p');
   bonus.className = 'fusion-card__bonus';
   bonus.textContent = bonusParts.length
-    ? `Bonus par réussite : ${bonusParts.join(' · ')}`
-    : 'Aucun bonus défini';
+    ? t('scripts.gacha.fusion.successBonus', { bonus: bonusParts.join(' · ') })
+    : t('scripts.gacha.fusion.noBonus');
 
   const totalBonus = document.createElement('p');
   totalBonus.className = 'fusion-card__feedback fusion-card__total';
-  totalBonus.textContent = 'Bonus cumulé : —';
+  totalBonus.textContent = t('scripts.gacha.fusion.totalBonus', { bonus: '—' });
 
   card.append(bodyFragment, actions, stats, bonus, totalBonus);
 
@@ -1463,7 +1472,7 @@ function renderFusionList() {
   if (!FUSION_DEFS.length) {
     const empty = document.createElement('p');
     empty.className = 'fusion-empty';
-    empty.textContent = 'Aucune fusion disponible pour le moment.';
+    empty.textContent = t('scripts.gacha.fusion.empty');
     empty.setAttribute('role', 'listitem');
     elements.fusionList.appendChild(empty);
     return;
@@ -1476,7 +1485,7 @@ function renderFusionList() {
   });
   elements.fusionList.appendChild(fragment);
   if (elements.fusionLog && !elements.fusionLog.textContent.trim()) {
-    setFusionLog('Sélectionnez une recette pour tenter votre première fusion.');
+    setFusionLog(t('scripts.app.fusion.prompt'));
   }
   updateFusionUI();
 }
@@ -1491,14 +1500,20 @@ function updateFusionUI() {
       return;
     }
     const state = getFusionStateById(def.id);
-    card.stats.textContent = `Tentatives : ${state.attempts} · Succès : ${state.successes}`;
+    card.stats.textContent = t('scripts.gacha.fusion.stats', {
+      attempts: state.attempts,
+      successes: state.successes
+    });
     let canAttempt = true;
     card.requirements.forEach(requirement => {
       const entry = gameState.elements?.[requirement.elementId];
       const available = getElementCurrentCount(entry);
       const availableText = available.toLocaleString('fr-FR');
       const requiredText = requirement.requiredCount.toLocaleString('fr-FR');
-      requirement.availabilityLabel.textContent = `Disponible : ${availableText} / ${requiredText}`;
+      requirement.availabilityLabel.textContent = t('scripts.gacha.fusion.availabilityProgress', {
+        available: availableText,
+        required: requiredText
+      });
       if (available < requirement.requiredCount) {
         canAttempt = false;
       }
@@ -1506,18 +1521,24 @@ function updateFusionUI() {
     card.button.disabled = !canAttempt;
     card.button.setAttribute('aria-disabled', canAttempt ? 'false' : 'true');
     card.status.textContent = canAttempt
-      ? 'Ingrédients disponibles'
-      : 'Ressources insuffisantes';
+      ? t('scripts.gacha.fusion.statusReady')
+      : t('scripts.gacha.fusion.statusMissing');
     const totalParts = [];
     if (def.rewards.apcFlat) {
       const totalApc = def.rewards.apcFlat * state.successes;
-      totalParts.push(`+${totalApc.toLocaleString('fr-FR')} APC cumulés`);
+      totalParts.push(t('scripts.gacha.fusion.apcTotal', {
+        value: totalApc.toLocaleString('fr-FR')
+      }));
     }
     if (def.rewards.apsFlat) {
       const totalAps = def.rewards.apsFlat * state.successes;
-      totalParts.push(`+${totalAps.toLocaleString('fr-FR')} APS cumulés`);
+      totalParts.push(t('scripts.gacha.fusion.apsTotal', {
+        value: totalAps.toLocaleString('fr-FR')
+      }));
     }
-    card.totalBonus.textContent = `Bonus cumulé : ${totalParts.length ? totalParts.join(' · ') : '—'}`;
+    card.totalBonus.textContent = t('scripts.gacha.fusion.totalBonus', {
+      bonus: totalParts.length ? totalParts.join(' · ') : '—'
+    });
   });
 }
 
@@ -1527,8 +1548,8 @@ function handleFusionAttempt(fusionId) {
     return;
   }
   if (!canAttemptFusion(definition)) {
-    setFusionLog('Vous n’avez pas assez de ressources pour cette fusion.', 'failure');
-    showToast('Ressources insuffisantes pour cette fusion.');
+    setFusionLog(t('scripts.gacha.fusion.logMissingResources'), 'failure');
+    showToast(t('scripts.gacha.fusion.toastMissingResources'));
     return;
   }
 
@@ -1558,12 +1579,17 @@ function handleFusionAttempt(fusionId) {
   saveGame();
 
   if (success) {
-    const rewardText = rewardSummary.length ? rewardSummary.join(' · ') : 'Aucun bonus.';
-    setFusionLog(`Fusion ${definition.name} réussie ! Bonus obtenu : ${rewardText}`, 'success');
-    showToast('Fusion réussie !');
+    const rewardText = rewardSummary.length
+      ? rewardSummary.join(' · ')
+      : t('scripts.gacha.fusion.noRewardSummary');
+    setFusionLog(t('scripts.gacha.fusion.logSuccess', {
+      name: definition.name,
+      reward: rewardText
+    }), 'success');
+    showToast(t('scripts.gacha.fusion.toastSuccess'));
   } else {
-    setFusionLog(`La fusion ${definition.name} a échoué. Les éléments ont été consommés.`, 'failure');
-    showToast('Fusion échouée.');
+    setFusionLog(t('scripts.gacha.fusion.logFailure', { name: definition.name }), 'failure');
+    showToast(t('scripts.gacha.fusion.toastFailure'));
   }
 }
 
@@ -1611,7 +1637,7 @@ function renderGachaResult(outcome) {
   container.style.removeProperty('--rarity-color');
 
   if (!outcome || !Array.isArray(outcome.focus) || !outcome.focus.length) {
-    container.textContent = 'Synthèse indisponible pour le moment.';
+    container.textContent = t('scripts.gacha.results.unavailable');
     return;
   }
 
@@ -1637,17 +1663,19 @@ function renderGachaResult(outcome) {
 
     const rarity = document.createElement('span');
     rarity.className = 'gacha-result-card__rarity';
-    rarity.textContent = entry.rarity?.label || entry.rarity?.id || 'Rareté inconnue';
+    rarity.textContent = entry.rarity?.label || entry.rarity?.id || t('scripts.gacha.results.unknownRarity');
 
     const name = document.createElement('span');
     name.className = 'gacha-result-card__name';
-    const baseName = entry.elementDef.name || entry.elementDef.symbol || 'Élément inconnu';
+    const baseName = entry.elementDef.name || entry.elementDef.symbol || t('scripts.gacha.results.unknownElement');
     const symbol = entry.elementDef.symbol && entry.elementDef.name ? ` (${entry.elementDef.symbol})` : '';
     name.textContent = `${baseName}${symbol}`;
 
     const status = document.createElement('span');
     status.className = 'gacha-result-card__status';
-    status.textContent = entry.isNew ? 'NOUVEAU !' : 'Déjà possédé';
+    status.textContent = entry.isNew
+      ? t('scripts.gacha.results.newTag')
+      : t('scripts.gacha.results.duplicateTag');
 
     if (entry.count > 1) {
       const count = document.createElement('span');
@@ -1668,7 +1696,7 @@ function renderGachaResult(outcome) {
   }
 
   if (!grid.children.length) {
-    container.textContent = 'Synthèse indisponible pour le moment.';
+    container.textContent = t('scripts.gacha.results.unavailable');
     return;
   }
 
@@ -1677,17 +1705,21 @@ function renderGachaResult(outcome) {
   const drawCount = Math.max(1, Math.floor(Number(outcome.drawCount) || 0));
   const summary = document.createElement('p');
   summary.className = 'gacha-result__summary';
-  const drawLabel = drawCount > 1 ? `Tirage x${drawCount}` : 'Tirage x1';
+  const drawLabel = drawCount > 1
+    ? t('scripts.gacha.results.drawLabel', { count: drawCount })
+    : t('scripts.gacha.results.drawSingle');
   const duplicateCount = Number(outcome.duplicateCount) || 0;
   const summaryParts = [drawLabel];
   if (newCount > 0) {
     const newLabel = newCount === 1
-      ? '1 nouvel élément'
-      : `${newCount} nouveaux éléments`;
+      ? t('scripts.gacha.results.newSingle')
+      : t('scripts.gacha.results.newPlural', { count: newCount });
     summaryParts.push(newLabel);
   }
   if (duplicateCount > 0) {
-    const duplicateLabel = duplicateCount === 1 ? '1 doublon' : `${duplicateCount} doublons`;
+    const duplicateLabel = duplicateCount === 1
+      ? t('scripts.gacha.results.duplicateSingle')
+      : t('scripts.gacha.results.duplicatePlural', { count: duplicateCount });
     summaryParts.push(duplicateLabel);
   }
   summary.textContent = summaryParts.join(' · ');
@@ -1697,14 +1729,18 @@ function renderGachaResult(outcome) {
 function formatTicketLabel(count) {
   const numeric = Math.max(0, Math.floor(Number(count) || 0));
   const formatted = numeric.toLocaleString('fr-FR');
-  const unit = numeric === 1 ? 'ticket' : 'tickets';
+  const unit = numeric === 1
+    ? t('scripts.gacha.tickets.single')
+    : t('scripts.gacha.tickets.plural');
   return `${formatted} ${unit}`;
 }
 
 function formatBonusTicketLabel(count) {
   const numeric = Math.max(0, Math.floor(Number(count) || 0));
   const formatted = numeric.toLocaleString('fr-FR');
-  const unit = numeric === 1 ? 'ticket Mach3' : 'tickets Mach3';
+  const unit = numeric === 1
+    ? t('scripts.gacha.tickets.bonusSingle')
+    : t('scripts.gacha.tickets.bonusPlural');
   return `${formatted} ${unit}`;
 }
 
@@ -1803,34 +1839,47 @@ function updateGachaUI() {
   }
   updateArcadeTicketDisplay();
   if (elements.gachaTicketModeLabel) {
-    elements.gachaTicketModeLabel.textContent = `Tirage x${gachaRollMode}`;
+    const modeLabel = gachaRollMode > 1
+      ? t('scripts.gacha.controls.modeMulti', { count: gachaRollMode })
+      : t('scripts.gacha.controls.modeSingle');
+    elements.gachaTicketModeLabel.textContent = modeLabel;
   }
   if (elements.gachaTicketModeButton) {
-    const modeLabel = `Tirage x${gachaRollMode}`;
-    elements.gachaTicketModeButton.setAttribute('aria-label', `Basculer le mode de tirage (actuel\u00a0: ${modeLabel})`);
-    elements.gachaTicketModeButton.title = `Mode actuel\u00a0: ${modeLabel}`;
+    const modeLabel = gachaRollMode > 1
+      ? t('scripts.gacha.controls.modeMulti', { count: gachaRollMode })
+      : t('scripts.gacha.controls.modeSingle');
+    elements.gachaTicketModeButton.setAttribute('aria-label', t('scripts.gacha.controls.toggleModeAria', {
+      mode: modeLabel
+    }));
+    elements.gachaTicketModeButton.title = t('scripts.gacha.controls.toggleModeTitle', {
+      mode: modeLabel
+    });
   }
   if (elements.gachaSunButton) {
     const gachaFree = isDevKitGachaFree();
     const totalCost = gachaRollMode * GACHA_TICKET_COST;
     const affordable = gachaFree || available >= totalCost;
     const busy = gachaAnimationInProgress;
-    const costLabel = gachaFree ? 'Gratuit' : formatTicketLabel(totalCost);
-    const drawLabel = gachaRollMode > 1 ? `tirage cosmique x${gachaRollMode}` : 'tirage cosmique';
+    const costLabel = gachaFree ? t('scripts.app.shop.free') : formatTicketLabel(totalCost);
+    const drawLabel = gachaRollMode > 1
+      ? t('scripts.gacha.controls.drawMulti', { count: gachaRollMode })
+      : t('scripts.gacha.controls.drawSingleLabel');
     let label;
     if (busy) {
-      label = 'Tirage cosmique en cours';
+      label = t('scripts.gacha.controls.drawInProgress');
     } else if (gachaFree) {
-      label = `Déclencher un ${drawLabel} (gratuit)`;
+      label = t('scripts.gacha.controls.drawFree', { draw: drawLabel });
     } else if (affordable) {
-      label = `Déclencher un ${drawLabel}`;
+      label = t('scripts.gacha.controls.drawPaid', { draw: drawLabel });
     } else {
-      label = `Tickets insuffisants pour un ${drawLabel}`;
+      label = t('scripts.gacha.controls.drawLocked', { draw: drawLabel });
     }
     elements.gachaSunButton.classList.toggle('is-locked', !affordable || busy);
     elements.gachaSunButton.setAttribute('aria-disabled', !affordable || busy ? 'true' : 'false');
     elements.gachaSunButton.setAttribute('aria-label', label);
-    elements.gachaSunButton.title = gachaFree ? label : `${label} (${costLabel})`;
+    elements.gachaSunButton.title = gachaFree
+      ? label
+      : t('scripts.gacha.controls.drawTitle', { label, cost: costLabel });
     if (busy) {
       elements.gachaSunButton.disabled = true;
     } else if (elements.gachaSunButton.disabled) {
@@ -1892,7 +1941,7 @@ function initParticulesGame() {
       const gained = gainGachaTickets(reward, { unlockTicketStar: true });
       saveGame();
       const rewardLabel = formatTicketLabel(gained);
-      showToast(`+${rewardLabel} grâce à Particules !`);
+      showToast(t('scripts.gacha.arcade.reward', { reward: rewardLabel }));
     },
     onSpecialTicket: (count = 0) => {
       const reward = Math.max(0, Math.floor(Number(count) || 0));
@@ -1902,7 +1951,7 @@ function initParticulesGame() {
       const gained = gainBonusParticulesTickets(reward);
       saveGame();
       const label = formatBonusTicketLabel(gained);
-      showToast(`+${label} !`);
+      showToast(t('scripts.gacha.arcade.bonus', { reward: label }));
     }
   });
   updateArcadeTicketDisplay();
@@ -1922,7 +1971,9 @@ function performGachaRoll(count = 1) {
   const totalCost = drawCount * GACHA_TICKET_COST;
 
   if (!gachaFree && available < totalCost) {
-    showToast(`Pas assez de tickets de tirage (nécessaire\u00a0: ${formatTicketLabel(totalCost)}).`);
+    showToast(t('scripts.gacha.errors.notEnoughTickets', {
+      cost: formatTicketLabel(totalCost)
+    }));
     return null;
   }
 
@@ -1931,7 +1982,7 @@ function performGachaRoll(count = 1) {
     return Array.isArray(pool) && pool.length > 0;
   });
   if (!hasAvailableElements) {
-    showToast('Aucun élément disponible dans les chambres de synthèse.');
+    showToast(t('scripts.gacha.errors.noElements'));
     return null;
   }
 
@@ -1943,13 +1994,13 @@ function performGachaRoll(count = 1) {
   for (let rollIndex = 0; rollIndex < drawCount; rollIndex += 1) {
     const rarity = pickGachaRarity();
     if (!rarity) {
-      showToast('Aucun élément disponible dans les chambres de synthèse.');
+      showToast(t('scripts.gacha.errors.noElements'));
       break;
     }
 
     const elementDef = pickRandomElementFromRarity(rarity.id);
     if (!elementDef) {
-      showToast('Flux instable, impossible de matérialiser un élément.');
+      showToast(t('scripts.gacha.errors.instableFlux'));
       continue;
     }
 
@@ -2034,8 +2085,8 @@ function getGachaToastMessage(outcome) {
     const single = results[0];
     if (!single?.elementDef) return '';
     return single.isNew
-      ? `Nouvel élément obtenu : ${single.elementDef.name} !`
-      : `${single.elementDef.name} rejoint à nouveau votre collection.`;
+      ? t('scripts.gacha.toast.newSingle', { name: single.elementDef.name })
+      : t('scripts.gacha.toast.duplicateSingle', { name: single.elementDef.name });
   }
 
   const newCount = Number.isFinite(Number(outcome.newCount))
@@ -2043,7 +2094,7 @@ function getGachaToastMessage(outcome) {
     : results.reduce((sum, result) => sum + (result.isNew ? 1 : 0), 0);
 
   if (newCount > 1) {
-    return `${newCount} nouveaux éléments découverts !`;
+    return t('scripts.gacha.toast.newMultiple', { count: newCount });
   }
 
   if (newCount === 1) {
@@ -2053,7 +2104,7 @@ function getGachaToastMessage(outcome) {
     const rawNew = results.find(result => result.isNew && result.elementDef);
     const target = focusNew || rawNew;
     if (target?.elementDef) {
-      return `Nouvel élément obtenu : ${target.elementDef.name} !`;
+      return t('scripts.gacha.toast.newSingle', { name: target.elementDef.name });
     }
   }
 
@@ -2063,14 +2114,17 @@ function getGachaToastMessage(outcome) {
   if (focusEntry?.elementDef) {
     const rarityLabel = focusEntry.rarity?.label || focusEntry.rarity?.id;
     if (rarityLabel) {
-      return `${focusEntry.elementDef.name} (${rarityLabel}) rejoint à nouveau votre collection.`;
+      return t('scripts.gacha.toast.duplicateWithRarity', {
+        name: focusEntry.elementDef.name,
+        rarity: rarityLabel
+      });
     }
-    return `${focusEntry.elementDef.name} rejoint à nouveau votre collection.`;
+    return t('scripts.gacha.toast.duplicateSingle', { name: focusEntry.elementDef.name });
   }
 
   const fallback = results[0];
   if (fallback?.elementDef) {
-    return `${fallback.elementDef.name} rejoint à nouveau votre collection.`;
+    return t('scripts.gacha.toast.duplicateSingle', { name: fallback.elementDef.name });
   }
 
   return '';
@@ -2805,7 +2859,9 @@ function collectTicketStar(event) {
     return;
   }
   const gained = gainGachaTickets(TICKET_STAR_CONFIG.rewardTickets);
-  showToast(gained === 1 ? 'Ticket de tirage obtenu !' : `+${gained} tickets de tirage !`);
+  showToast(gained === 1
+    ? t('scripts.gacha.ticketStar.single')
+    : t('scripts.gacha.ticketStar.multiple', { count: gained }));
   if (ticketStarState.element && ticketStarState.element.parentNode) {
     ticketStarState.element.remove();
   }

--- a/scripts/modules/info.js
+++ b/scripts/modules/info.js
@@ -710,7 +710,9 @@ function renderElementBonuses() {
     if (summaryType === 'family') {
       const status = document.createElement('span');
       status.className = 'element-bonus-card__status';
-      status.textContent = summary.isComplete ? 'Famille complète' : 'Famille en cours';
+      status.textContent = summary.isComplete
+        ? t('scripts.info.collections.complete')
+        : t('scripts.info.collections.inProgress');
       header.appendChild(status);
     }
 
@@ -911,7 +913,7 @@ function renderElementBonuses() {
 
       const title = document.createElement('h5');
       title.className = 'element-bonus-section__title';
-      title.textContent = 'Boosts actifs';
+      title.textContent = t('scripts.info.sections.activeBoosts');
       section.appendChild(title);
 
       const tags = document.createElement('div');
@@ -938,7 +940,7 @@ function renderElementBonuses() {
 
       const title = document.createElement('h5');
       title.className = 'element-bonus-section__title';
-      title.textContent = 'Effets spéciaux';
+      title.textContent = t('scripts.info.sections.specialEffects');
       section.appendChild(title);
 
       const list = document.createElement('ul');
@@ -967,7 +969,7 @@ function renderElementBonuses() {
     if (!details.children.length) {
       const empty = document.createElement('p');
       empty.className = 'element-bonus-empty';
-      empty.textContent = 'Bonus inactifs';
+      empty.textContent = t('scripts.info.sections.inactiveBonuses');
       details.appendChild(empty);
     }
 
@@ -1069,7 +1071,7 @@ function renderShopBonuses() {
   if (!visibleSummaries.length) {
     const empty = document.createElement('p');
     empty.className = 'element-bonus-empty shop-bonus-empty';
-    empty.textContent = 'Aucune amélioration disponible.';
+    empty.textContent = t('scripts.info.shop.noneAvailable');
     container.appendChild(empty);
     lastVisibleShopBonusIds = new Set();
     return;
@@ -1105,9 +1107,11 @@ function renderShopBonuses() {
     const status = document.createElement('span');
     status.className = 'element-bonus-card__status shop-bonus-card__status';
     if (summary.level > 0) {
-      status.textContent = `Niveau ${summary.level.toLocaleString('fr-FR')}`;
+      status.textContent = t('scripts.info.shop.level', {
+        level: summary.level.toLocaleString('fr-FR')
+      });
     } else {
-      status.textContent = 'Non acheté';
+      status.textContent = t('scripts.info.shop.notPurchased');
     }
     header.appendChild(status);
 
@@ -1140,23 +1144,23 @@ function renderShopBonuses() {
         hasEffect = true;
       };
 
-      appendEffect('APC +', formatShopFlatBonus(summary.clickAdd));
-      appendEffect('APS +', formatShopFlatBonus(summary.autoAdd));
-      appendEffect('APC ×', formatShopMultiplierBonus(summary.clickMult));
-      appendEffect('APS ×', formatShopMultiplierBonus(summary.autoMult));
+      appendEffect(t('scripts.info.shop.bonus.apcFlat'), formatShopFlatBonus(summary.clickAdd));
+      appendEffect(t('scripts.info.shop.bonus.apsFlat'), formatShopFlatBonus(summary.autoAdd));
+      appendEffect(t('scripts.info.shop.bonus.apcMult'), formatShopMultiplierBonus(summary.clickMult));
+      appendEffect(t('scripts.info.shop.bonus.apsMult'), formatShopMultiplierBonus(summary.autoMult));
 
       if (hasEffect) {
         card.appendChild(effects);
       } else {
         const empty = document.createElement('p');
         empty.className = 'element-bonus-empty shop-bonus-empty';
-        empty.textContent = 'Bonus en attente de seuil.';
+        empty.textContent = t('scripts.info.shop.pendingThreshold');
         card.appendChild(empty);
       }
     } else {
       const locked = document.createElement('p');
       locked.className = 'element-bonus-empty shop-bonus-empty';
-      locked.textContent = 'Achetez cette amélioration pour activer ses effets.';
+      locked.textContent = t('scripts.info.shop.locked');
       card.appendChild(locked);
     }
 

--- a/scripts/modules/metaux-match3.js
+++ b/scripts/modules/metaux-match3.js
@@ -1195,7 +1195,9 @@ class MetauxMatch3Game {
       this.timerValueElement.textContent = this.formatSeconds(this.timerState.current, { decimals: 1 });
     }
     if (this.timerMaxElement) {
-      this.timerMaxElement.textContent = `Max ${this.formatSeconds(this.timerState.max, { decimals: 0 })}`;
+      this.timerMaxElement.textContent = t('scripts.metaux.timer.max', {
+        value: this.formatSeconds(this.timerState.max, { decimals: 0 })
+      });
     }
     if (this.timerFillElement) {
       const ratio = this.timerState.max > 0 ? this.timerState.current / this.timerState.max : 0;
@@ -1245,7 +1247,7 @@ class MetauxMatch3Game {
     this.populateBoard();
     this.refreshBoard();
     this.prepareNewSession();
-    this.updateMessage('Nouvelle session : enchaînez les alliages !');
+    this.updateMessage(t('scripts.metaux.session.start'));
   }
 
   getTileKey(row, col) {


### PR DESCRIPTION
## Summary
- replace hard-coded interface labels in the music controls, collection placeholders, and other UI helpers with calls to the global translator
- internationalize gacha fusion cards, results, ticket controls, and related toasts by mapping them to new translation entries
- add corresponding French and English strings for the new keys and localize info and Métaux Match3 overlays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da55742a60832e8dd5e9f209ca1c35