### PR TITLE
Normalize i18n placeholders to single-brace syntax

### DIFF
--- a/scripts/i18n/en.json
+++ b/scripts/i18n/en.json
@@ -39,7 +39,7 @@
         "modeSingle": "Single draw",
         "tickets": {
           "single": "0 ticket",
-          "plural": "{{count}} tickets"
+          "plural": "{count} tickets"
         },
         "sunButton": "Trigger a cosmic draw",
         "sunAlt": "Cosmic sun",
@@ -390,9 +390,9 @@
         }
       },
       "reward": {
-        "description": "Adds +{{bonus}} to the global boost for manual and automatic production (×{{total}} for this tier)."
+        "description": "Adds +{bonus} to the global boost for manual and automatic production (×{total} for this tier)."
       },
-      "description": "Reach {{target}} cumulative atoms, {{flavor}}."
+      "description": "Reach {target} cumulative atoms, {flavor}."
     },
     "uiText": {
       "options": {
@@ -458,7 +458,7 @@
         }
       },
       "frenzy": "Frenzy",
-      "frenzyActivate": "Activate {{label}} ({{multiplier}})",
+      "frenzyActivate": "Activate {label} ({multiplier})",
       "pageUnlocked": "New page unlocked!",
       "shop": {
         "limitReached": "Limit reached",
@@ -475,14 +475,14 @@
         "addFilesHint": "Add your audio files to Assets/Music to enable music.",
         "disabled": "Music disabled.",
         "selectTrack": "Select a track to start the music.",
-        "missingDisplay": "{{name}} (file missing)",
+        "missingDisplay": "{name} (file missing)",
         "missingSuffix": " (file missing)",
         "unsupportedSuffix": ". Audio playback unavailable on this device.",
         "errorSuffix": ". Unable to play the audio file.",
         "awaitingInteractionSuffix": ". Music will start after your first interaction.",
         "pausedSuffix": ". Playback paused.",
-        "looping": "Looping: {{track}}",
-        "volumeLabel": "Music volume: {{value}}%",
+        "looping": "Looping: {track}",
+        "volumeLabel": "Music volume: {value}%",
         "muted": "Music muted",
         "missing": "Track not found",
         "fileMissing": "The file for this track is missing."
@@ -553,31 +553,31 @@
       "rarityProgress": {
         "unavailable": "Rarities unavailable",
         "empty": "No elements",
-        "summary": "{{owned}} / {{total}} elements"
+        "summary": "{owned} / {total} elements"
       },
       "fusion": {
-        "successChance": "Success chance: {{chance}}",
+        "successChance": "Success chance: {chance}",
         "availabilityInitial": "Available: 0",
         "tryButton": "Attempt fusion",
-        "tryButtonAria": "Attempt {{name}} fusion",
+        "tryButtonAria": "Attempt {name} fusion",
         "checking": "Checking ingredients…",
-        "stats": "Attempts: {{attempts}} · Successes: {{successes}}",
-        "successBonus": "Reward per success: {{bonus}}",
+        "stats": "Attempts: {attempts} · Successes: {successes}",
+        "successBonus": "Reward per success: {bonus}",
         "noBonus": "No bonus defined",
-        "totalBonus": "Total bonus: {{bonus}}",
-        "apcBonus": "+{{value}} APC",
-        "apsBonus": "+{{value}} APS",
-        "apcTotal": "+{{value}} APC total",
-        "apsTotal": "+{{value}} APS total",
-        "availabilityProgress": "Available: {{available}} / {{required}}",
+        "totalBonus": "Total bonus: {bonus}",
+        "apcBonus": "+{value} APC",
+        "apsBonus": "+{value} APS",
+        "apcTotal": "+{value} APC total",
+        "apsTotal": "+{value} APS total",
+        "availabilityProgress": "Available: {available} / {required}",
         "statusReady": "Ingredients available",
         "statusMissing": "Insufficient resources",
         "logMissingResources": "You don't have enough resources for this fusion.",
         "toastMissingResources": "Not enough resources for this fusion.",
         "noRewardSummary": "No bonus.",
-        "logSuccess": "{{name}} fusion succeeded! Reward earned: {{reward}}",
+        "logSuccess": "{name} fusion succeeded! Reward earned: {reward}",
         "toastSuccess": "Fusion succeeded!",
-        "logFailure": "{{name}} fusion failed. Ingredients were consumed.",
+        "logFailure": "{name} fusion failed. Ingredients were consumed.",
         "toastFailure": "Fusion failed."
       },
       "results": {
@@ -586,12 +586,12 @@
         "unknownElement": "Unknown element",
         "newTag": "NEW!",
         "duplicateTag": "Already owned",
-        "drawLabel": "Draw x{{count}}",
+        "drawLabel": "Draw x{count}",
         "drawSingle": "Draw x1",
         "newSingle": "1 new element",
-        "newPlural": "{{count}} new elements",
+        "newPlural": "{count} new elements",
         "duplicateSingle": "1 duplicate",
-        "duplicatePlural": "{{count}} duplicates"
+        "duplicatePlural": "{count} duplicates"
       },
       "tickets": {
         "single": "ticket",
@@ -601,35 +601,35 @@
       },
       "controls": {
         "modeSingle": "Draw x1",
-        "modeMulti": "Draw x{{count}}",
-        "toggleModeAria": "Toggle draw mode (current: {{mode}})",
-        "toggleModeTitle": "Current mode: {{mode}}",
-        "drawMulti": "cosmic draw x{{count}}",
+        "modeMulti": "Draw x{count}",
+        "toggleModeAria": "Toggle draw mode (current: {mode})",
+        "toggleModeTitle": "Current mode: {mode}",
+        "drawMulti": "cosmic draw x{count}",
         "drawSingleLabel": "cosmic draw",
         "drawInProgress": "Cosmic draw in progress",
-        "drawFree": "Trigger a {{draw}} (free)",
-        "drawPaid": "Trigger a {{draw}}",
-        "drawLocked": "Not enough tickets for a {{draw}}",
-        "drawTitle": "{{label}} ({{cost}})"
+        "drawFree": "Trigger a {draw} (free)",
+        "drawPaid": "Trigger a {draw}",
+        "drawLocked": "Not enough tickets for a {draw}",
+        "drawTitle": "{label} ({cost})"
       },
       "arcade": {
-        "reward": "+{{reward}} thanks to Particules!",
-        "bonus": "+{{reward}}!"
+        "reward": "+{reward} thanks to Particules!",
+        "bonus": "+{reward}!"
       },
       "errors": {
-        "notEnoughTickets": "Not enough draw tickets (required: {{cost}}).",
+        "notEnoughTickets": "Not enough draw tickets (required: {cost}).",
         "noElements": "No elements available in the synthesis chambers.",
         "instableFlux": "Unstable flux, unable to materialize an element."
       },
       "toast": {
-        "newSingle": "New element obtained: {{name}}!",
-        "duplicateSingle": "{{name}} rejoins your collection.",
-        "newMultiple": "{{count}} new elements discovered!",
-        "duplicateWithRarity": "{{name}} ({{rarity}}) rejoins your collection."
+        "newSingle": "New element obtained: {name}!",
+        "duplicateSingle": "{name} rejoins your collection.",
+        "newMultiple": "{count} new elements discovered!",
+        "duplicateWithRarity": "{name} ({rarity}) rejoins your collection."
       },
       "ticketStar": {
         "single": "Draw ticket obtained!",
-        "multiple": "+{{count}} draw tickets!"
+        "multiple": "+{count} draw tickets!"
       }
     },
     "appData": {
@@ -834,21 +834,21 @@
         "set": "Collection bonus",
         "complete": "Complete collection",
         "bonus": "Bonus",
-        "apcFlat": "APC +{{value}}",
-        "apsFlat": "APS +{{value}}",
-        "apcFlatUnique": "APC +{{value}} per unique element",
-        "apsFlatUnique": "APS +{{value}} per unique element",
-        "apcFlatDuplicate": "APC +{{value}} per duplicate",
-        "apsFlatDuplicate": "APS +{{value}} per duplicate",
-        "apcMultiplier": "APC {{value}}",
-        "apsMultiplier": "APS {{value}}",
-        "critChance": "Crit chance {{value}}",
-        "critMultiplier": "Crit multiplier {{value}}",
-        "ticketInterval": "Every {{duration}}",
-        "requireCopies": "from {{count}} {{unit}}",
-        "requireUnique": "at least {{count}} {{unit}}",
+        "apcFlat": "APC +{value}",
+        "apsFlat": "APS +{value}",
+        "apcFlatUnique": "APC +{value} per unique element",
+        "apsFlatUnique": "APS +{value} per unique element",
+        "apcFlatDuplicate": "APC +{value} per duplicate",
+        "apsFlatDuplicate": "APS +{value} per duplicate",
+        "apcMultiplier": "APC {value}",
+        "apsMultiplier": "APS {value}",
+        "critChance": "Crit chance {value}",
+        "critMultiplier": "Crit multiplier {value}",
+        "ticketInterval": "Every {duration}",
+        "requireCopies": "from {count} {unit}",
+        "requireUnique": "at least {count} {unit}",
         "requireFull": "complete collection required",
-        "rarityAmplify": "Amplifies {{rarity}}: {{effects}}"
+        "rarityAmplify": "Amplifies {rarity}: {effects}"
       },
       "collections": {
         "complete": "Family complete",
@@ -861,7 +861,7 @@
       },
       "shop": {
         "noneAvailable": "No upgrades available.",
-        "level": "Level {{level}}",
+        "level": "Level {level}",
         "notPurchased": "Not purchased",
         "bonus": {
           "apcFlat": "APC +",
@@ -875,7 +875,7 @@
     },
     "metaux": {
       "timer": {
-        "max": "Max {{value}}"
+        "max": "Max {value}"
       },
       "session": {
         "start": "New session: chain those alloys!"

--- a/scripts/i18n/fr.json
+++ b/scripts/i18n/fr.json
@@ -39,7 +39,7 @@
         "modeSingle": "Tirage x1",
         "tickets": {
           "single": "0 ticket",
-          "plural": "{{count}} tickets"
+          "plural": "{count} tickets"
         },
         "sunButton": "Déclencher un tirage cosmique",
         "sunAlt": "Soleil cosmique",
@@ -390,9 +390,9 @@
         }
       },
       "reward": {
-        "description": "Ajoute +{{bonus}} au Boost global sur la production manuelle et automatique (×{{total}} pour ce palier)."
+        "description": "Ajoute +{bonus} au Boost global sur la production manuelle et automatique (×{total} pour ce palier)."
       },
-      "description": "Atteignez {{target}} atomes cumulés, {{flavor}}."
+      "description": "Atteignez {target} atomes cumulés, {flavor}."
     },
     "uiText": {
       "options": {
@@ -458,7 +458,7 @@
         }
       },
       "frenzy": "Frénésie",
-      "frenzyActivate": "Activer la {{label}} ({{multiplier}})",
+      "frenzyActivate": "Activer la {label} ({multiplier})",
       "pageUnlocked": "Nouvelle page débloquée !",
       "shop": {
         "limitReached": "Limite atteinte",
@@ -475,14 +475,14 @@
         "addFilesHint": "Ajoutez vos fichiers audio dans Assets/Music pour activer la musique.",
         "disabled": "Musique désactivée.",
         "selectTrack": "Sélectionnez une piste pour lancer la musique.",
-        "missingDisplay": "{{name}} (fichier manquant)",
+        "missingDisplay": "{name} (fichier manquant)",
         "missingSuffix": " (fichier manquant)",
         "unsupportedSuffix": ". Lecture audio indisponible sur cet appareil.",
         "errorSuffix": ". Impossible de lire le fichier audio.",
         "awaitingInteractionSuffix": ". La musique démarre après votre première interaction.",
         "pausedSuffix": ". Lecture en pause.",
-        "looping": "Lecture en boucle : {{track}}",
-        "volumeLabel": "Volume musique : {{value}}%",
+        "looping": "Lecture en boucle : {track}",
+        "volumeLabel": "Volume musique : {value}%",
         "muted": "Musique coupée",
         "missing": "Piste introuvable",
         "fileMissing": "Le fichier de cette piste est manquant."
@@ -553,31 +553,31 @@
       "rarityProgress": {
         "unavailable": "Raretés indisponibles",
         "empty": "Aucun élément",
-        "summary": "{{owned}} / {{total}} éléments"
+        "summary": "{owned} / {total} éléments"
       },
       "fusion": {
-        "successChance": "Chance de réussite : {{chance}}",
+        "successChance": "Chance de réussite : {chance}",
         "availabilityInitial": "Disponible : 0",
         "tryButton": "Tenter la fusion",
-        "tryButtonAria": "Tenter la fusion {{name}}",
+        "tryButtonAria": "Tenter la fusion {name}",
         "checking": "Vérification des ingrédients…",
-        "stats": "Tentatives : {{attempts}} · Succès : {{successes}}",
-        "successBonus": "Bonus par réussite : {{bonus}}",
+        "stats": "Tentatives : {attempts} · Succès : {successes}",
+        "successBonus": "Bonus par réussite : {bonus}",
         "noBonus": "Aucun bonus défini",
-        "totalBonus": "Bonus cumulé : {{bonus}}",
-        "apcBonus": "+{{value}} APC",
-        "apsBonus": "+{{value}} APS",
-        "apcTotal": "+{{value}} APC cumulés",
-        "apsTotal": "+{{value}} APS cumulés",
-        "availabilityProgress": "Disponible : {{available}} / {{required}}",
+        "totalBonus": "Bonus cumulé : {bonus}",
+        "apcBonus": "+{value} APC",
+        "apsBonus": "+{value} APS",
+        "apcTotal": "+{value} APC cumulés",
+        "apsTotal": "+{value} APS cumulés",
+        "availabilityProgress": "Disponible : {available} / {required}",
         "statusReady": "Ingrédients disponibles",
         "statusMissing": "Ressources insuffisantes",
         "logMissingResources": "Vous n’avez pas assez de ressources pour cette fusion.",
         "toastMissingResources": "Ressources insuffisantes pour cette fusion.",
         "noRewardSummary": "Aucun bonus.",
-        "logSuccess": "Fusion {{name}} réussie ! Bonus obtenu : {{reward}}",
+        "logSuccess": "Fusion {name} réussie ! Bonus obtenu : {reward}",
         "toastSuccess": "Fusion réussie !",
-        "logFailure": "La fusion {{name}} a échoué. Les éléments ont été consommés.",
+        "logFailure": "La fusion {name} a échoué. Les éléments ont été consommés.",
         "toastFailure": "Fusion échouée."
       },
       "results": {
@@ -586,12 +586,12 @@
         "unknownElement": "Élément inconnu",
         "newTag": "NOUVEAU !",
         "duplicateTag": "Déjà possédé",
-        "drawLabel": "Tirage x{{count}}",
+        "drawLabel": "Tirage x{count}",
         "drawSingle": "Tirage x1",
         "newSingle": "1 nouvel élément",
-        "newPlural": "{{count}} nouveaux éléments",
+        "newPlural": "{count} nouveaux éléments",
         "duplicateSingle": "1 doublon",
-        "duplicatePlural": "{{count}} doublons"
+        "duplicatePlural": "{count} doublons"
       },
       "tickets": {
         "single": "ticket",
@@ -601,35 +601,35 @@
       },
       "controls": {
         "modeSingle": "Tirage x1",
-        "modeMulti": "Tirage x{{count}}",
-        "toggleModeAria": "Basculer le mode de tirage (actuel\u00a0: {{mode}})",
-        "toggleModeTitle": "Mode actuel\u00a0: {{mode}}",
-        "drawMulti": "tirage cosmique x{{count}}",
+        "modeMulti": "Tirage x{count}",
+        "toggleModeAria": "Basculer le mode de tirage (actuel\u00a0: {mode})",
+        "toggleModeTitle": "Mode actuel\u00a0: {mode}",
+        "drawMulti": "tirage cosmique x{count}",
         "drawSingleLabel": "tirage cosmique",
         "drawInProgress": "Tirage cosmique en cours",
-        "drawFree": "Déclencher un {{draw}} (gratuit)",
-        "drawPaid": "Déclencher un {{draw}}",
-        "drawLocked": "Tickets insuffisants pour un {{draw}}",
-        "drawTitle": "{{label}} ({{cost}})"
+        "drawFree": "Déclencher un {draw} (gratuit)",
+        "drawPaid": "Déclencher un {draw}",
+        "drawLocked": "Tickets insuffisants pour un {draw}",
+        "drawTitle": "{label} ({cost})"
       },
       "arcade": {
-        "reward": "+{{reward}} grâce à Particules !",
-        "bonus": "+{{reward}} !"
+        "reward": "+{reward} grâce à Particules !",
+        "bonus": "+{reward} !"
       },
       "errors": {
-        "notEnoughTickets": "Pas assez de tickets de tirage (nécessaire\u00a0: {{cost}}).",
+        "notEnoughTickets": "Pas assez de tickets de tirage (nécessaire\u00a0: {cost}).",
         "noElements": "Aucun élément disponible dans les chambres de synthèse.",
         "instableFlux": "Flux instable, impossible de matérialiser un élément."
       },
       "toast": {
-        "newSingle": "Nouvel élément obtenu : {{name}} !",
-        "duplicateSingle": "{{name}} rejoint à nouveau votre collection.",
-        "newMultiple": "{{count}} nouveaux éléments découverts !",
-        "duplicateWithRarity": "{{name}} ({{rarity}}) rejoint à nouveau votre collection."
+        "newSingle": "Nouvel élément obtenu : {name} !",
+        "duplicateSingle": "{name} rejoint à nouveau votre collection.",
+        "newMultiple": "{count} nouveaux éléments découverts !",
+        "duplicateWithRarity": "{name} ({rarity}) rejoint à nouveau votre collection."
       },
       "ticketStar": {
         "single": "Ticket de tirage obtenu !",
-        "multiple": "+{{count}} tickets de tirage !"
+        "multiple": "+{count} tickets de tirage !"
       }
     },
     "appData": {
@@ -834,21 +834,21 @@
         "set": "Bonus de collection",
         "complete": "Collection complète",
         "bonus": "Bonus",
-        "apcFlat": "APC +{{value}}",
-        "apsFlat": "APS +{{value}}",
-        "apcFlatUnique": "APC +{{value}} par élément unique",
-        "apsFlatUnique": "APS +{{value}} par élément unique",
-        "apcFlatDuplicate": "APC +{{value}} par doublon",
-        "apsFlatDuplicate": "APS +{{value}} par doublon",
-        "apcMultiplier": "APC {{value}}",
-        "apsMultiplier": "APS {{value}}",
-        "critChance": "Chance critique {{value}}",
-        "critMultiplier": "Multiplicateur critique {{value}}",
-        "ticketInterval": "Toutes les {{duration}}",
-        "requireCopies": "dès {{count}} {{unit}}",
-        "requireUnique": "minimum {{count}} {{unit}}",
+        "apcFlat": "APC +{value}",
+        "apsFlat": "APS +{value}",
+        "apcFlatUnique": "APC +{value} par élément unique",
+        "apsFlatUnique": "APS +{value} par élément unique",
+        "apcFlatDuplicate": "APC +{value} par doublon",
+        "apsFlatDuplicate": "APS +{value} par doublon",
+        "apcMultiplier": "APC {value}",
+        "apsMultiplier": "APS {value}",
+        "critChance": "Chance critique {value}",
+        "critMultiplier": "Multiplicateur critique {value}",
+        "ticketInterval": "Toutes les {duration}",
+        "requireCopies": "dès {count} {unit}",
+        "requireUnique": "minimum {count} {unit}",
         "requireFull": "collection complète requise",
-        "rarityAmplify": "Amplifie {{rarity}} : {{effects}}"
+        "rarityAmplify": "Amplifie {rarity} : {effects}"
       },
       "collections": {
         "complete": "Famille complète",
@@ -861,7 +861,7 @@
       },
       "shop": {
         "noneAvailable": "Aucune amélioration disponible.",
-        "level": "Niveau {{level}}",
+        "level": "Niveau {level}",
         "notPurchased": "Non acheté",
         "bonus": {
           "apcFlat": "APC +",
@@ -875,7 +875,7 @@
     },
     "metaux": {
       "timer": {
-        "max": "Max {{value}}"
+        "max": "Max {value}"
       },
       "session": {
         "start": "Nouvelle session : enchaînez les alliages !"

--- a/scripts/modules/i18n.js
+++ b/scripts/modules/i18n.js
@@ -25,7 +25,8 @@
     if (typeof message !== 'string' || !params || typeof params !== 'object') {
       return message;
     }
-    return message.replace(/\{\s*([^\s{}]+)\s*\}/g, (match, token) => {
+    const normalizedMessage = message.replace(/\{\{\s*([^{}\s]+)\s*\}\}/g, '{$1}');
+    return normalizedMessage.replace(/\{\s*([^\s{}]+)\s*\}/g, (match, token) => {
       const value = params[token];
       return value == null ? match : String(value);
     });


### PR DESCRIPTION
## Summary
- update the i18n formatter to normalize double-brace placeholders before replacement
- convert English and French translation strings to the single-brace token syntax supported by the formatter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da62e26748832ebb77333f4592d4f5