### PR TITLE
feat: add locale-aware helpers and refresh UI on language change

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -537,15 +537,33 @@ const ATOM_SCALE_TROPHY_PRESETS = [
 
 globalThis.ATOM_SCALE_TROPHY_DATA = ATOM_SCALE_TROPHY_PRESETS;
 
+function getCurrentLocale() {
+  if (globalThis.i18n && typeof globalThis.i18n.getCurrentLocale === 'function') {
+    return globalThis.i18n.getCurrentLocale();
+  }
+  return 'fr-FR';
+}
+
+function formatLocalizedNumber(value, options) {
+  if (globalThis.i18n && typeof globalThis.i18n.formatNumber === 'function') {
+    return globalThis.i18n.formatNumber(value, options);
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '';
+  }
+  return numeric.toLocaleString(getCurrentLocale(), options);
+}
+
 function formatAtomScaleBonus(value) {
   if (!Number.isFinite(value)) {
     return '0';
   }
   const roundedInteger = Math.round(value);
   if (Math.abs(value - roundedInteger) <= 1e-9) {
-    return roundedInteger.toLocaleString('fr-FR');
+    return formatLocalizedNumber(roundedInteger);
   }
-  return value.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return formatLocalizedNumber(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 function createAtomScaleTrophies() {

--- a/scripts/modules/app-data.js
+++ b/scripts/modules/app-data.js
@@ -25,7 +25,7 @@
   })();
 
   const FALLBACK_NUMBER_LOCALE = 'fr-FR';
-  const resolvedNumberLocale = (() => {
+  let resolvedNumberLocale = (() => {
     const navigatorLanguage = typeof global.navigator === 'object' && global.navigator
       ? global.navigator.language ?? global.navigator.userLanguage
       : null;
@@ -48,11 +48,30 @@
     if (!Number.isFinite(numeric)) {
       return '0';
     }
+    if (globalThis.i18n && typeof globalThis.i18n.formatNumber === 'function') {
+      const formatted = globalThis.i18n.formatNumber(numeric, options);
+      if (formatted) {
+        return formatted;
+      }
+    }
+    const locale = globalThis.i18n && typeof globalThis.i18n.getCurrentLocale === 'function'
+      ? globalThis.i18n.getCurrentLocale()
+      : resolvedNumberLocale;
     try {
-      return numeric.toLocaleString(resolvedNumberLocale, options);
+      return numeric.toLocaleString(locale, options);
     } catch (error) {
       return numeric.toLocaleString(FALLBACK_NUMBER_LOCALE, options);
     }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('i18n:languagechange', event => {
+      if (event?.detail?.locale) {
+        resolvedNumberLocale = event.detail.locale;
+      } else if (globalThis.i18n && typeof globalThis.i18n.getCurrentLocale === 'function') {
+        resolvedNumberLocale = globalThis.i18n.getCurrentLocale();
+      }
+    });
   }
 
   const DEFAULT_ATOM_SCALE_TROPHY_SPECS = [

--- a/scripts/modules/layered-number.js
+++ b/scripts/modules/layered-number.js
@@ -432,7 +432,14 @@ class LayeredNumber {
     if (this.layer === 0) {
       const value = this.mantissa * Math.pow(10, this.exponent);
       if (Math.abs(this.exponent) < 6) {
-        return (this.sign * value).toLocaleString('fr-FR', { maximumFractionDigits: 2 });
+        const numeric = this.sign * value;
+        if (globalThis.i18n && typeof globalThis.i18n.formatNumber === 'function') {
+          return globalThis.i18n.formatNumber(numeric, { maximumFractionDigits: 2 });
+        }
+        const locale = globalThis.i18n && typeof globalThis.i18n.getCurrentLocale === 'function'
+          ? globalThis.i18n.getCurrentLocale()
+          : 'fr-FR';
+        return numeric.toLocaleString(locale, { maximumFractionDigits: 2 });
       }
       const mant = (this.sign * this.mantissa).toFixed(2);
       return `${mant}e${this.exponent}`;


### PR DESCRIPTION
## Summary
- extend the i18n module with shared Intl-based formatters, helper APIs, and language change notifications
- replace hardcoded toLocale* calls across gameplay modules with the new locale-aware helpers and adjust formatting logic
- refresh cached UI views (status bars, gacha, Métaux) when the locale changes to reflect the selected language

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6d94a398832e8f48c415054bc31a