### PR TITLE
Fix translation helper naming conflicts

### DIFF
--- a/scripts/modules/gacha.js
+++ b/scripts/modules/gacha.js
@@ -1,6 +1,6 @@
 const DEFAULT_GACHA_TICKET_COST = 1;
 
-const translate = (() => {
+const gachaTranslate = (() => {
   const translator = typeof globalThis !== 'undefined' && typeof globalThis.t === 'function'
     ? globalThis.t.bind(globalThis)
     : null;
@@ -68,8 +68,8 @@ const DEFAULT_GACHA_RARITIES = [
   id: entry.id,
   weight: entry.weight,
   color: entry.color,
-  label: translate(entry.labelKey),
-  description: translate(entry.descriptionKey)
+  label: gachaTranslate(entry.labelKey),
+  description: gachaTranslate(entry.descriptionKey)
 }));
 
 function sanitizeGachaRarities(rawRarities) {

--- a/scripts/modules/game-data.js
+++ b/scripts/modules/game-data.js
@@ -1,6 +1,6 @@
 const CONFIG = typeof window !== 'undefined' && window.GAME_CONFIG ? window.GAME_CONFIG : {};
 
-const translate = (() => {
+const gameDataTranslate = (() => {
   const translator = typeof globalThis !== 'undefined' && typeof globalThis.t === 'function'
     ? globalThis.t.bind(globalThis)
     : null;
@@ -102,7 +102,7 @@ function normalizeFusionDefinition(entry, index = 0) {
   }
   const name = typeof entry.name === 'string' && entry.name.trim()
     ? entry.name.trim()
-    : translate('scripts.gameData.fusions.defaultName', { number: index + 1 });
+    : gameDataTranslate('scripts.gameData.fusions.defaultName', { number: index + 1 });
   const description = typeof entry.description === 'string' ? entry.description.trim() : '';
   const inputSource = Array.isArray(entry.inputs)
     ? entry.inputs
@@ -878,7 +878,7 @@ const CATEGORY_LABEL_KEYS = {
 };
 
 const CATEGORY_LABELS = Object.fromEntries(
-  Object.entries(CATEGORY_LABEL_KEYS).map(([key, messageKey]) => [key, translate(messageKey)])
+  Object.entries(CATEGORY_LABEL_KEYS).map(([key, messageKey]) => [key, gameDataTranslate(messageKey)])
 );
 
 const ELEMENT_GROUP_BONUS_CONFIG = (() => {


### PR DESCRIPTION
## Summary
- rename the helper used to translate game-data strings so it no longer collides with other globals
- rename the gacha module translator helper and keep localized rarity labels working

## Testing
- python -m http.server 8000 (manual Playwright smoke test while serving the app)


------
https://chatgpt.com/codex/tasks/task_e_68da731d6d14832e8174f8609e215994