### PR TITLE
Add MyLocalServ launcher for local server usage

### DIFF
--- a/MyLocalServ.cmd
+++ b/MyLocalServ.cmd
@@ -1,0 +1,34 @@
+@echo off
+setlocal
+set "EXIT_CODE=0"
+set "SCRIPT_DIR=%~dp0"
+set "IS_DOUBLE_CLICK=0"
+echo %CMDCMDLINE% | find /I "%~f0" >nul 2>&1 && set "IS_DOUBLE_CLICK=1"
+pushd "%SCRIPT_DIR%" >nul
+if not "%~1"=="" (
+  set "PORT=%~1"
+)
+where node >nul 2>&1
+if errorlevel 1 (
+  echo [MyLocalServ] Node.js doit etre installe et accessible via la commande ^"node^".
+  echo Telechargez-le depuis https://nodejs.org/ et redemarrez cette fenetre.
+  set "EXIT_CODE=1"
+  goto :end
+)
+if defined PORT (
+  echo [MyLocalServ] Demarrage du serveur sur le port %PORT%...
+) else (
+  echo [MyLocalServ] Demarrage du serveur sur le port par defaut (8080)...
+)
+node "%SCRIPT_DIR%MyLocalServ.js"
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" (
+  echo [MyLocalServ] Le serveur s'est termine avec le code %EXIT_CODE%.
+)
+:end
+popd >nul
+if "%IS_DOUBLE_CLICK%"=="1" (
+  echo.
+  pause
+)
+endlocal & exit /b %EXIT_CODE%

--- a/MyLocalServ.js
+++ b/MyLocalServ.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = Number(process.env.PORT) || 8080;
+const ROOT = path.resolve(__dirname);
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav'
+};
+
+function resolveFilePath(requestUrl) {
+  const parsed = url.parse(requestUrl);
+  const decodedPath = decodeURIComponent(parsed.pathname || '/');
+  const safePath = decodedPath.replace(/\\/g, '/');
+  let candidate = path.join(ROOT, safePath);
+
+  if (!candidate.startsWith(ROOT)) {
+    return null;
+  }
+
+  if (safePath.endsWith('/')) {
+    candidate = path.join(candidate, 'index.html');
+  }
+
+  return candidate;
+}
+
+function serveFile(filePath, res) {
+  fs.stat(filePath, (error, stats) => {
+    if (error) {
+      if (error.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('404 - Not Found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('500 - Internal Server Error');
+      }
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      serveFile(path.join(filePath, 'index.html'), res);
+      return;
+    }
+
+    const extension = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[extension] || 'application/octet-stream';
+    const stream = fs.createReadStream(filePath);
+
+    stream.on('open', () => {
+      res.writeHead(200, {
+        'Content-Type': contentType,
+        'Content-Length': stats.size,
+        'Cache-Control': 'no-cache'
+      });
+      stream.pipe(res);
+    });
+
+    stream.on('error', () => {
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('500 - Internal Server Error');
+    });
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const filePath = resolveFilePath(req.url || '/');
+
+  if (!filePath) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('403 - Forbidden');
+    return;
+  }
+
+  serveFile(filePath, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`MyLocalServ prêt sur http://localhost:${PORT}`);
+  console.log('Appuyez sur Ctrl+C pour arrêter le serveur.');
+});

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -200,6 +200,29 @@ Une fois ces étapes terminées, rechargez la page : la langue apparaîtra autom
 * **Accessibilité** : navigation par onglets, compteurs `aria-live`, animations désactivables via classes CSS.
 * **Sauvegarde** : export/import JSON ; le format stocke les tickets, la progression de collection, les multiplicateurs et les paramètres de l’étoile à tickets.
 
+### 🚀 Lancer un serveur local
+
+Le projet inclut un lanceur Node.js (`MyLocalServ`) afin de servir les fichiers statiques sans blocage des requêtes `fetch`. Installez au préalable [Node.js](https://nodejs.org/) (version LTS recommandée), puis choisissez la méthode adaptée à votre système :
+
+#### Windows
+
+* **Double-clic** : ouvrez `MyLocalServ.cmd`. La fenêtre affiche l’URL (`http://localhost:8080` par défaut) et reste ouverte pour vous permettre d’arrêter le serveur proprement.
+* **Terminal** : exécutez la commande ci-dessous pour lancer le serveur depuis l’invite de commandes et, si besoin, préciser un port personnalisé.
+
+```bat
+cd Atom2Univers
+MyLocalServ.cmd 3000
+```
+
+#### macOS / Linux (et terminaux en général)
+
+```bash
+cd Atom2Univers
+node MyLocalServ.js
+```
+
+Le serveur démarre par défaut sur `http://localhost:8080`. Définissez la variable d’environnement `PORT` (ou passez un argument à `MyLocalServ.cmd`) pour changer le port si nécessaire. Appuyez sur `Ctrl+C` pour l’arrêter.
+
 ---
 
 ## 🎯 Objectif


### PR DESCRIPTION
## Summary
- add a Node.js launcher (MyLocalServ) to serve the project locally for proper fetch support
- document how to run the new launcher in the README
- add a Windows `.cmd` wrapper so the launcher can be started via double-click and clarify the usage instructions

## Testing
- node MyLocalServ.js

------
https://chatgpt.com/codex/tasks/task_e_68da869f8620832eaf83d423ee2c2971