### PR TITLE
Fix options page welcome card localization

### DIFF
--- a/scripts/i18n/en.json
+++ b/scripts/i18n/en.json
@@ -481,6 +481,11 @@
           "generic": "Skin updated."
         }
       },
+      "options": {
+        "brickSkin": {
+          "unlocked": "Choose the appearance of Particles bricks."
+        }
+      },
       "frenzy": "Frenzy",
       "frenzyActivate": "Activate {label} ({multiplier})",
       "frenzyToast": "{label} ×{multiplier} for {duration}!",

--- a/scripts/i18n/fr.json
+++ b/scripts/i18n/fr.json
@@ -466,6 +466,11 @@
           "generic": "Skin mis à jour."
         }
       },
+      "options": {
+        "brickSkin": {
+          "unlocked": "Choisissez l’apparence des briques de Particules."
+        }
+      },
       "frenzy": "Frénésie",
       "frenzyActivate": "Activer la {label} ({multiplier})",
       "frenzyToast": "{label} ×{multiplier} pendant {duration} !",

--- a/scripts/modules/i18n.js
+++ b/scripts/modules/i18n.js
@@ -119,6 +119,23 @@
     return String(value);
   }
 
+  function getResource(key) {
+    if (typeof key !== 'string' || !key.trim()) {
+      return null;
+    }
+    const value = getValueFromPath(resources, key.trim());
+    if (value == null) {
+      return null;
+    }
+    if (typeof value === 'object') {
+      const cloned = cloneResource(value);
+      if (cloned != null) {
+        return cloned;
+      }
+    }
+    return value;
+  }
+
   function updateElementTranslations(root = global.document) {
     if (!root || typeof root.querySelectorAll !== 'function') {
       return;
@@ -397,6 +414,7 @@
 
   const api = {
     t: translate,
+    getResource,
     setLanguage,
     getCurrentLanguage,
     getAvailableLanguages,


### PR DESCRIPTION
## Summary
- load the options welcome card content from the active i18n resources so the copy switches language correctly
- expose a helper to safely fetch localized resources and reuse translated fallbacks in the app
- translate the brick skin status message and add the missing localization keys for both languages

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da9e866688832ea9852f119816e5db