### PR TITLE
Fix options welcome card language updates

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1977,7 +1977,29 @@ function renderOptionsWelcomeContent() {
   }
 }
 
-renderOptionsWelcomeContent();
+function refreshOptionsWelcomeContent() {
+  renderOptionsWelcomeContent();
+  updateOptionsIntroDetails();
+}
+
+function subscribeOptionsWelcomeContentUpdates() {
+  const api = getI18nApi();
+  if (api && typeof api.onLanguageChanged === 'function') {
+    api.onLanguageChanged(() => {
+      refreshOptionsWelcomeContent();
+    });
+    return;
+  }
+  if (typeof globalThis !== 'undefined'
+    && typeof globalThis.addEventListener === 'function') {
+    globalThis.addEventListener('i18n:languagechange', () => {
+      refreshOptionsWelcomeContent();
+    });
+  }
+}
+
+refreshOptionsWelcomeContent();
+subscribeOptionsWelcomeContentUpdates();
 
 function updateLanguageSelectorValue(language) {
   if (!elements.languageSelect) {
@@ -8020,8 +8042,7 @@ if (elements.languageSelect) {
           i18n.updateTranslations(document);
         }
         updateLanguageSelectorValue(requestedLanguage);
-        renderOptionsWelcomeContent();
-        updateOptionsIntroDetails();
+        refreshOptionsWelcomeContent();
         updateBrickSkinOption();
         updateUI();
         showToast(t('scripts.app.language.updated'));


### PR DESCRIPTION
## Summary
- refresh the options welcome card text alongside the arcade details visibility when language resources are applied
- hook the welcome card renderer to i18n language change notifications and reuse the helper during manual language selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad416df08832e85418bb35da63a92