### PR TITLE
Add localized SCALE trophy target strings

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -5,6 +5,32 @@
  */
 const SHOP_MAX_PURCHASE_DEFAULT = 1000;
 
+function translateOrDefault(key, fallback, params) {
+  if (typeof key !== 'string' || !key.trim()) {
+    return fallback;
+  }
+
+  const api = globalThis.i18n;
+  const translator = api && typeof api.t === 'function'
+    ? api.t
+    : typeof globalThis.t === 'function'
+      ? globalThis.t
+      : null;
+
+  if (translator) {
+    try {
+      const translated = translator(key, params);
+      if (typeof translated === 'string' && translated && translated !== key) {
+        return translated;
+      }
+    } catch (error) {
+      console.warn('Unable to translate key', key, error);
+    }
+  }
+
+  return fallback;
+}
+
 function getBuildingLevel(context, id) {
   if (!context || typeof context !== 'object') {
     return 0;
@@ -371,171 +397,218 @@ function createShopBuildingDefinitions() {
   ].map(withDefaults);
 }
 
+function createAtomScalePreset({ id, targetText, amount, name, flavor }) {
+  const baseKey = typeof id === 'string' && id.trim()
+    ? `scripts.appData.atomScale.trophies.${id}`
+    : '';
+
+  return {
+    id,
+    targetText,
+    amount,
+    name,
+    flavor,
+    i18nBaseKey: baseKey
+  };
+}
+
 const ATOM_SCALE_TROPHY_PRESETS = [
-  {
+  createAtomScalePreset({
     id: 'scaleHumanCell',
     name: 'Échelle : cellule humaine',
     targetText: '10^14',
     flavor: 'l’équivalent d’une cellule humaine « moyenne »',
     amount: { type: 'layer0', mantissa: 1, exponent: 14 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleSandGrain',
     name: 'Échelle : grain de sable',
     targetText: '10^19',
     flavor: 'la masse d’un grain de sable (~1 mm)',
     amount: { type: 'layer0', mantissa: 1, exponent: 19 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleAnt',
     name: 'Échelle : fourmi',
     targetText: '10^20',
     flavor: 'comparable à une fourmi (~5 mg)',
     amount: { type: 'layer0', mantissa: 1, exponent: 20 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleWaterDrop',
     name: 'Échelle : goutte d’eau',
     targetText: '5 × 10^21',
     flavor: 'la quantité d’atomes contenue dans une goutte d’eau de 0,05 mL',
     amount: { type: 'layer0', mantissa: 5, exponent: 21 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scalePaperclip',
     name: 'Échelle : trombone',
     targetText: '10^22',
     flavor: 'l’équivalent d’un trombone en fer (~1 g)',
     amount: { type: 'layer0', mantissa: 1, exponent: 22 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleCoin',
     name: 'Échelle : pièce',
     targetText: '10^23',
     flavor: 'la masse atomique d’une pièce de monnaie (~7,5 g)',
     amount: { type: 'layer0', mantissa: 1, exponent: 23 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleApple',
     name: 'Échelle : pomme',
     targetText: '10^25',
     flavor: 'la masse atomique d’une pomme (~100 g)',
     amount: { type: 'layer0', mantissa: 1, exponent: 25 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleSmartphone',
     name: 'Échelle : smartphone',
     targetText: '3 × 10^25',
     flavor: 'autant qu’un smartphone moderne (~180 g)',
     amount: { type: 'layer0', mantissa: 3, exponent: 25 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleWaterLitre',
     name: 'Échelle : litre d’eau',
     targetText: '10^26',
     flavor: 'l’équivalent d’un litre d’eau',
     amount: { type: 'layer0', mantissa: 1, exponent: 26 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleHuman',
     name: 'Échelle : être humain',
     targetText: '7 × 10^27',
     flavor: 'comparable à un humain de 70 kg',
     amount: { type: 'layer0', mantissa: 7, exponent: 27 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scalePiano',
     name: 'Échelle : piano',
     targetText: '10^29',
     flavor: 'équivaut à un piano (~450 kg)',
     amount: { type: 'layer0', mantissa: 1, exponent: 29 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleCar',
     name: 'Échelle : voiture compacte',
     targetText: '10^30',
     flavor: 'autant qu’une voiture compacte (~1,3 t)',
     amount: { type: 'layer0', mantissa: 1, exponent: 30 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleElephant',
     name: 'Échelle : éléphant',
     targetText: '3 × 10^31',
     flavor: 'équivaut à un éléphant (~6 t)',
     amount: { type: 'layer0', mantissa: 3, exponent: 31 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleBoeing747',
     name: 'Échelle : Boeing 747',
     targetText: '10^33',
     flavor: 'autant qu’un Boeing 747',
     amount: { type: 'layer0', mantissa: 1, exponent: 33 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scalePyramid',
     name: 'Échelle : pyramide de Khéops',
     targetText: '2 × 10^35',
     flavor: 'la masse d’atomes de la grande pyramide de Khéops',
     amount: { type: 'layer0', mantissa: 2, exponent: 35 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleAtmosphere',
     name: 'Échelle : atmosphère terrestre',
     targetText: '2 × 10^44',
     flavor: 'équivaut à l’atmosphère terrestre complète',
     amount: { type: 'layer0', mantissa: 2, exponent: 44 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleOceans',
     name: 'Échelle : océans terrestres',
     targetText: '10^47',
     flavor: 'autant que tous les océans de la Terre',
     amount: { type: 'layer0', mantissa: 1, exponent: 47 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleEarth',
     name: 'Échelle : Terre',
     targetText: '10^50',
     flavor: 'égale la masse atomique de la planète Terre',
     amount: { type: 'layer0', mantissa: 1, exponent: 50 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleSun',
     name: 'Échelle : Soleil',
     targetText: '10^57',
     flavor: 'équivaut au Soleil',
     amount: { type: 'layer0', mantissa: 1, exponent: 57 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleMilkyWay',
     name: 'Échelle : Voie lactée',
     targetText: '10^69',
     flavor: 'comparable à la Voie lactée entière',
     amount: { type: 'layer0', mantissa: 1, exponent: 69 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleLocalGroup',
     name: 'Échelle : Groupe local',
     targetText: '10^71',
     flavor: 'autant que le Groupe local de galaxies',
     amount: { type: 'layer0', mantissa: 1, exponent: 71 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleVirgoCluster',
     name: 'Échelle : superamas de la Vierge',
     targetText: '10^74',
     flavor: 'équivaut au superamas de la Vierge',
     amount: { type: 'layer0', mantissa: 1, exponent: 74 }
-  },
-  {
+  }),
+  createAtomScalePreset({
     id: 'scaleObservableUniverse',
     name: 'Échelle : univers observable',
     targetText: '10^80',
     flavor: 'atteignez le total estimé d’atomes de l’univers observable',
     amount: { type: 'layer0', mantissa: 1, exponent: 80 }
-  }
+  })
 ];
 
-globalThis.ATOM_SCALE_TROPHY_DATA = ATOM_SCALE_TROPHY_PRESETS;
+function resolveAtomScalePreset(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const { id, targetText, amount, name, flavor, i18nBaseKey } = entry;
+  const fallbackName = typeof name === 'string' ? name : '';
+  const fallbackFlavor = typeof flavor === 'string' ? flavor : '';
+  const fallbackTarget = typeof targetText === 'string' ? targetText : '';
+  const resolvedName = i18nBaseKey
+    ? translateOrDefault(`${i18nBaseKey}.name`, fallbackName)
+    : fallbackName;
+  const resolvedFlavor = i18nBaseKey
+    ? translateOrDefault(`${i18nBaseKey}.flavor`, fallbackFlavor)
+    : fallbackFlavor;
+  const resolvedTarget = i18nBaseKey
+    ? translateOrDefault(`${i18nBaseKey}.target`, fallbackTarget)
+    : fallbackTarget;
+
+  return {
+    id,
+    targetText: resolvedTarget,
+    amount,
+    name: resolvedName,
+    flavor: resolvedFlavor
+  };
+}
+
+const RESOLVED_ATOM_SCALE_TROPHY_PRESETS = ATOM_SCALE_TROPHY_PRESETS
+  .map(resolveAtomScalePreset)
+  .filter(Boolean);
+
+globalThis.ATOM_SCALE_TROPHY_DATA = RESOLVED_ATOM_SCALE_TROPHY_PRESETS;
 
 function getCurrentLocale() {
   if (globalThis.i18n && typeof globalThis.i18n.getCurrentLocale === 'function') {
@@ -568,20 +641,31 @@ function formatAtomScaleBonus(value) {
 
 function createAtomScaleTrophies() {
   const bonusPerTrophy = 2;
-  return ATOM_SCALE_TROPHY_PRESETS.map((entry, index) => {
+  return RESOLVED_ATOM_SCALE_TROPHY_PRESETS.map((entry, index) => {
     const displayBonus = formatAtomScaleBonus(bonusPerTrophy);
     const displayTotal = formatAtomScaleBonus(1 + bonusPerTrophy);
+    const descriptionFallback = `Atteignez ${entry.targetText} atomes cumulés, ${entry.flavor}.`;
+    const rewardFallback = `Ajoute +${displayBonus} au Boost global sur la production manuelle et automatique (×${displayTotal} pour ce palier).`;
+
     return {
       id: entry.id,
       name: entry.name,
-      description: `Atteignez ${entry.targetText} atomes cumulés, ${entry.flavor}.`,
+      description: translateOrDefault(
+        'scripts.appData.atomScale.trophies.description',
+        descriptionFallback,
+        { target: entry.targetText, flavor: entry.flavor }
+      ),
       condition: {
         type: 'lifetimeAtoms',
         amount: entry.amount
       },
       reward: {
         trophyMultiplierAdd: bonusPerTrophy,
-        description: `Ajoute +${displayBonus} au Boost global sur la production manuelle et automatique (×${displayTotal} pour ce palier).`
+        description: translateOrDefault(
+          'scripts.appData.atomScale.trophies.reward',
+          rewardFallback,
+          { bonus: displayBonus, total: displayTotal }
+        )
       },
       order: index
     };

--- a/scripts/i18n/embedded-resources.js
+++ b/scripts/i18n/embedded-resources.js
@@ -765,100 +765,123 @@
             "trophies": {
               "description": "Atteignez {target} atomes cumulés, {flavor}.",
               "reward": "Ajoute +{bonus} au Boost global sur la production manuelle et automatique (×{total} pour ce palier).",
-              "scaleHumanCell": {
-                "name": "Échelle : cellule humaine",
-                "flavor": "l’équivalent d’une cellule humaine « moyenne »"
-              },
-              "scaleSandGrain": {
-                "name": "Échelle : grain de sable",
-                "flavor": "la masse d’un grain de sable (~1 mm)"
-              },
-              "scaleAnt": {
-                "name": "Échelle : fourmi",
-                "flavor": "comparable à une fourmi (~5 mg)"
-              },
-              "scaleWaterDrop": {
-                "name": "Échelle : goutte d’eau",
-                "flavor": "la quantité d’atomes contenue dans une goutte d’eau de 0,05 mL"
-              },
-              "scalePaperclip": {
-                "name": "Échelle : trombone",
-                "flavor": "l’équivalent d’un trombone en fer (~1 g)"
-              },
-              "scaleCoin": {
-                "name": "Échelle : pièce",
-                "flavor": "la masse atomique d’une pièce de monnaie (~7,5 g)"
-              },
-              "scaleApple": {
-                "name": "Échelle : pomme",
-                "flavor": "la masse atomique d’une pomme (~100 g)"
-              },
-              "scaleSmartphone": {
-                "name": "Échelle : smartphone",
-                "flavor": "autant qu’un smartphone moderne (~180 g)"
-              },
-              "scaleWaterLitre": {
-                "name": "Échelle : litre d’eau",
-                "flavor": "l’équivalent d’un litre d’eau (~300 g)"
-              },
-              "scaleHuman": {
-                "name": "Échelle : être humain",
-                "flavor": "comparable à un humain de 70 kg"
-              },
-              "scalePiano": {
-                "name": "Échelle : piano",
-                "flavor": "équivaut à un piano (~450 kg)"
-              },
-              "scaleCar": {
-                "name": "Échelle : voiture compacte",
-                "flavor": "autant qu’une voiture compacte (~1,3 t)"
-              },
-              "scaleElephant": {
-                "name": "Échelle : éléphant",
-                "flavor": "équivaut à un éléphant (~6 t)"
-              },
-              "scaleBoeing747": {
-                "name": "Échelle : Boeing 747",
-                "flavor": "autant qu’un Boeing 747"
-              },
-              "scalePyramid": {
-                "name": "Échelle : pyramide de Khéops",
-                "flavor": "la masse d’atomes de la grande pyramide de Khéops"
-              },
-              "scaleAtmosphere": {
-                "name": "Échelle : atmosphère terrestre",
-                "flavor": "équivaut à l’atmosphère terrestre complète"
-              },
-              "scaleOceans": {
-                "name": "Échelle : océans terrestres",
-                "flavor": "autant que tous les océans de la Terre"
-              },
-              "scaleEarth": {
-                "name": "Échelle : Terre",
-                "flavor": "égale la masse atomique de la planète Terre"
-              },
-              "scaleSun": {
-                "name": "Échelle : Soleil",
-                "flavor": "équivaut au Soleil"
-              },
-              "scaleMilkyWay": {
-                "name": "Échelle : Voie lactée",
-                "flavor": "comparable à la Voie lactée entière"
-              },
-              "scaleLocalGroup": {
-                "name": "Échelle : Groupe local",
-                "flavor": "autant que le Groupe local de galaxies"
-              },
-              "scaleVirgoCluster": {
-                "name": "Échelle : superamas de la Vierge",
-                "flavor": "équivaut au superamas de la Vierge"
-              },
-              "scaleObservableUniverse": {
-                "name": "Échelle : univers observable",
-                "flavor": "atteignez le total estimé d’atomes de l’univers observable"
-              }
+            "scaleHumanCell": {
+              "target": "10^14",
+              "name": "Échelle : cellule humaine",
+              "flavor": "l’équivalent d’une cellule humaine « moyenne »"
+            },
+            "scaleSandGrain": {
+              "target": "10^19",
+              "name": "Échelle : grain de sable",
+              "flavor": "la masse d’un grain de sable (~1 mm)"
+            },
+            "scaleAnt": {
+              "target": "10^20",
+              "name": "Échelle : fourmi",
+              "flavor": "comparable à une fourmi (~5 mg)"
+            },
+            "scaleWaterDrop": {
+              "target": "5 × 10^21",
+              "name": "Échelle : goutte d’eau",
+              "flavor": "la quantité d’atomes contenue dans une goutte d’eau de 0,05 mL"
+            },
+            "scalePaperclip": {
+              "target": "10^22",
+              "name": "Échelle : trombone",
+              "flavor": "l’équivalent d’un trombone en fer (~1 g)"
+            },
+            "scaleCoin": {
+              "target": "10^23",
+              "name": "Échelle : pièce",
+              "flavor": "la masse atomique d’une pièce de monnaie (~7,5 g)"
+            },
+            "scaleApple": {
+              "target": "10^25",
+              "name": "Échelle : pomme",
+              "flavor": "la masse atomique d’une pomme (~100 g)"
+            },
+            "scaleSmartphone": {
+              "target": "3 × 10^25",
+              "name": "Échelle : smartphone",
+              "flavor": "autant qu’un smartphone moderne (~180 g)"
+            },
+            "scaleWaterLitre": {
+              "target": "10^26",
+              "name": "Échelle : litre d’eau",
+              "flavor": "l’équivalent d’un litre d’eau (~300 g)"
+            },
+            "scaleHuman": {
+              "target": "7 × 10^27",
+              "name": "Échelle : être humain",
+              "flavor": "comparable à un humain de 70 kg"
+            },
+            "scalePiano": {
+              "target": "10^29",
+              "name": "Échelle : piano",
+              "flavor": "équivaut à un piano (~450 kg)"
+            },
+            "scaleCar": {
+              "target": "10^30",
+              "name": "Échelle : voiture compacte",
+              "flavor": "autant qu’une voiture compacte (~1,3 t)"
+            },
+            "scaleElephant": {
+              "target": "3 × 10^31",
+              "name": "Échelle : éléphant",
+              "flavor": "équivaut à un éléphant (~6 t)"
+            },
+            "scaleBoeing747": {
+              "target": "10^33",
+              "name": "Échelle : Boeing 747",
+              "flavor": "autant qu’un Boeing 747"
+            },
+            "scalePyramid": {
+              "target": "2 × 10^35",
+              "name": "Échelle : pyramide de Khéops",
+              "flavor": "la masse d’atomes de la grande pyramide de Khéops"
+            },
+            "scaleAtmosphere": {
+              "target": "2 × 10^44",
+              "name": "Échelle : atmosphère terrestre",
+              "flavor": "équivaut à l’atmosphère terrestre complète"
+            },
+            "scaleOceans": {
+              "target": "10^47",
+              "name": "Échelle : océans terrestres",
+              "flavor": "autant que tous les océans de la Terre"
+            },
+            "scaleEarth": {
+              "target": "10^50",
+              "name": "Échelle : Terre",
+              "flavor": "égale la masse atomique de la planète Terre"
+            },
+            "scaleSun": {
+              "target": "10^57",
+              "name": "Échelle : Soleil",
+              "flavor": "équivaut au Soleil"
+            },
+            "scaleMilkyWay": {
+              "target": "10^69",
+              "name": "Échelle : Voie lactée",
+              "flavor": "comparable à la Voie lactée entière"
+            },
+            "scaleLocalGroup": {
+              "target": "10^71",
+              "name": "Échelle : Groupe local",
+              "flavor": "autant que le Groupe local de galaxies"
+            },
+            "scaleVirgoCluster": {
+              "target": "10^74",
+              "name": "Échelle : superamas de la Vierge",
+              "flavor": "équivaut au superamas de la Vierge"
+            },
+            "scaleObservableUniverse": {
+              "target": "10^80",
+              "name": "Échelle : univers observable",
+              "flavor": "atteignez le total estimé d’atomes de l’univers observable"
             }
-          },
+          }
+        },
           "milestones": {
             "autoSynthesis": "Collectez {amount} atomes pour débloquer la synthèse automatique.",
             "quantumGloves": "Atteignez {amount} atomes pour améliorer vos gants quantiques.",
@@ -1784,100 +1807,123 @@
             "trophies": {
               "description": "Reach {target} total atoms, {flavor}.",
               "reward": "Adds +{bonus} to the global manual and automatic production boost (×{total} for this tier).",
-              "scaleHumanCell": {
-                "name": "Scale: Human cell",
-                "flavor": "roughly equal to an average human cell"
-              },
-              "scaleSandGrain": {
-                "name": "Scale: Grain of sand",
-                "flavor": "mass of a grain of sand (~1 mm)"
-              },
-              "scaleAnt": {
-                "name": "Scale: Ant",
-                "flavor": "comparable to an ant (~5 mg)"
-              },
-              "scaleWaterDrop": {
-                "name": "Scale: Water drop",
-                "flavor": "atoms in a 0.05 mL drop of water"
-              },
-              "scalePaperclip": {
-                "name": "Scale: Paperclip",
-                "flavor": "equivalent to an iron paperclip (~1 g)"
-              },
-              "scaleCoin": {
-                "name": "Scale: Coin",
-                "flavor": "atomic mass of a coin (~7.5 g)"
-              },
-              "scaleApple": {
-                "name": "Scale: Apple",
-                "flavor": "atomic mass of an apple (~100 g)"
-              },
-              "scaleSmartphone": {
-                "name": "Scale: Smartphone",
-                "flavor": "similar to a modern smartphone (~180 g)"
-              },
-              "scaleWaterLitre": {
-                "name": "Scale: Liter of water",
-                "flavor": "equivalent to a liter of water (~300 g)"
-              },
-              "scaleHuman": {
-                "name": "Scale: Human being",
-                "flavor": "comparable to a 70 kg human"
-              },
-              "scalePiano": {
-                "name": "Scale: Piano",
-                "flavor": "matches a piano (~450 kg)"
-              },
-              "scaleCar": {
-                "name": "Scale: Compact car",
-                "flavor": "same as a compact car (~1.3 t)"
-              },
-              "scaleElephant": {
-                "name": "Scale: Elephant",
-                "flavor": "equivalent to an elephant (~6 t)"
-              },
-              "scaleBoeing747": {
-                "name": "Scale: Boeing 747",
-                "flavor": "same mass as a Boeing 747"
-              },
-              "scalePyramid": {
-                "name": "Scale: Great Pyramid of Giza",
-                "flavor": "atoms of the Great Pyramid of Giza"
-              },
-              "scaleAtmosphere": {
-                "name": "Scale: Earth's atmosphere",
-                "flavor": "equal to the full atmosphere of Earth"
-              },
-              "scaleOceans": {
-                "name": "Scale: Earth's oceans",
-                "flavor": "matches all Earth's oceans"
-              },
-              "scaleEarth": {
-                "name": "Scale: Earth",
-                "flavor": "equals the atomic mass of planet Earth"
-              },
-              "scaleSun": {
-                "name": "Scale: Sun",
-                "flavor": "equivalent to the Sun"
-              },
-              "scaleMilkyWay": {
-                "name": "Scale: Milky Way",
-                "flavor": "comparable to the entire Milky Way"
-              },
-              "scaleLocalGroup": {
-                "name": "Scale: Local Group",
-                "flavor": "same as the Local Group of galaxies"
-              },
-              "scaleVirgoCluster": {
-                "name": "Scale: Virgo Supercluster",
-                "flavor": "equivalent to the Virgo Supercluster"
-              },
-              "scaleObservableUniverse": {
-                "name": "Scale: Observable universe",
-                "flavor": "reach the estimated atoms of the observable universe"
-              }
+            "scaleHumanCell": {
+              "target": "10^14",
+              "name": "Scale: Human cell",
+              "flavor": "roughly equal to an average human cell"
+            },
+            "scaleSandGrain": {
+              "target": "10^19",
+              "name": "Scale: Grain of sand",
+              "flavor": "mass of a grain of sand (~1 mm)"
+            },
+            "scaleAnt": {
+              "target": "10^20",
+              "name": "Scale: Ant",
+              "flavor": "comparable to an ant (~5 mg)"
+            },
+            "scaleWaterDrop": {
+              "target": "5 × 10^21",
+              "name": "Scale: Water drop",
+              "flavor": "atoms in a 0.05 mL drop of water"
+            },
+            "scalePaperclip": {
+              "target": "10^22",
+              "name": "Scale: Paperclip",
+              "flavor": "equivalent to an iron paperclip (~1 g)"
+            },
+            "scaleCoin": {
+              "target": "10^23",
+              "name": "Scale: Coin",
+              "flavor": "atomic mass of a coin (~7.5 g)"
+            },
+            "scaleApple": {
+              "target": "10^25",
+              "name": "Scale: Apple",
+              "flavor": "atomic mass of an apple (~100 g)"
+            },
+            "scaleSmartphone": {
+              "target": "3 × 10^25",
+              "name": "Scale: Smartphone",
+              "flavor": "similar to a modern smartphone (~180 g)"
+            },
+            "scaleWaterLitre": {
+              "target": "10^26",
+              "name": "Scale: Liter of water",
+              "flavor": "equivalent to a liter of water (~300 g)"
+            },
+            "scaleHuman": {
+              "target": "7 × 10^27",
+              "name": "Scale: Human being",
+              "flavor": "comparable to a 70 kg human"
+            },
+            "scalePiano": {
+              "target": "10^29",
+              "name": "Scale: Piano",
+              "flavor": "matches a piano (~450 kg)"
+            },
+            "scaleCar": {
+              "target": "10^30",
+              "name": "Scale: Compact car",
+              "flavor": "same as a compact car (~1.3 t)"
+            },
+            "scaleElephant": {
+              "target": "3 × 10^31",
+              "name": "Scale: Elephant",
+              "flavor": "equivalent to an elephant (~6 t)"
+            },
+            "scaleBoeing747": {
+              "target": "10^33",
+              "name": "Scale: Boeing 747",
+              "flavor": "same mass as a Boeing 747"
+            },
+            "scalePyramid": {
+              "target": "2 × 10^35",
+              "name": "Scale: Great Pyramid of Giza",
+              "flavor": "atoms of the Great Pyramid of Giza"
+            },
+            "scaleAtmosphere": {
+              "target": "2 × 10^44",
+              "name": "Scale: Earth's atmosphere",
+              "flavor": "equal to the full atmosphere of Earth"
+            },
+            "scaleOceans": {
+              "target": "10^47",
+              "name": "Scale: Earth's oceans",
+              "flavor": "matches all Earth's oceans"
+            },
+            "scaleEarth": {
+              "target": "10^50",
+              "name": "Scale: Earth",
+              "flavor": "equals the atomic mass of planet Earth"
+            },
+            "scaleSun": {
+              "target": "10^57",
+              "name": "Scale: Sun",
+              "flavor": "equivalent to the Sun"
+            },
+            "scaleMilkyWay": {
+              "target": "10^69",
+              "name": "Scale: Milky Way",
+              "flavor": "comparable to the entire Milky Way"
+            },
+            "scaleLocalGroup": {
+              "target": "10^71",
+              "name": "Scale: Local Group",
+              "flavor": "same as the Local Group of galaxies"
+            },
+            "scaleVirgoCluster": {
+              "target": "10^74",
+              "name": "Scale: Virgo Supercluster",
+              "flavor": "equivalent to the Virgo Supercluster"
+            },
+            "scaleObservableUniverse": {
+              "target": "10^80",
+              "name": "Scale: Observable universe",
+              "flavor": "reach the estimated atoms of the observable universe"
             }
-          },
+          }
+        },
           "milestones": {
             "autoSynthesis": "Collect {amount} atoms to unlock automatic synthesis.",
             "quantumGloves": "Reach {amount} atoms to improve your quantum gloves.",

--- a/scripts/i18n/en.json
+++ b/scripts/i18n/en.json
@@ -886,94 +886,117 @@
           "description": "Reach {target} total atoms, {flavor}.",
           "reward": "Adds +{bonus} to the global manual and automatic production boost (×{total} for this tier).",
           "scaleHumanCell": {
+            "target": "10^14",
             "name": "Scale: Human cell",
             "flavor": "roughly equal to an average human cell"
           },
           "scaleSandGrain": {
+            "target": "10^19",
             "name": "Scale: Grain of sand",
             "flavor": "mass of a grain of sand (~1 mm)"
           },
           "scaleAnt": {
+            "target": "10^20",
             "name": "Scale: Ant",
             "flavor": "comparable to an ant (~5 mg)"
           },
           "scaleWaterDrop": {
+            "target": "5 × 10^21",
             "name": "Scale: Water drop",
             "flavor": "atoms in a 0.05 mL drop of water"
           },
           "scalePaperclip": {
+            "target": "10^22",
             "name": "Scale: Paperclip",
             "flavor": "equivalent to an iron paperclip (~1 g)"
           },
           "scaleCoin": {
+            "target": "10^23",
             "name": "Scale: Coin",
             "flavor": "atomic mass of a coin (~7.5 g)"
           },
           "scaleApple": {
+            "target": "10^25",
             "name": "Scale: Apple",
             "flavor": "atomic mass of an apple (~100 g)"
           },
           "scaleSmartphone": {
+            "target": "3 × 10^25",
             "name": "Scale: Smartphone",
             "flavor": "similar to a modern smartphone (~180 g)"
           },
           "scaleWaterLitre": {
+            "target": "10^26",
             "name": "Scale: Liter of water",
             "flavor": "equivalent to a liter of water (~300 g)"
           },
           "scaleHuman": {
+            "target": "7 × 10^27",
             "name": "Scale: Human being",
             "flavor": "comparable to a 70 kg human"
           },
           "scalePiano": {
+            "target": "10^29",
             "name": "Scale: Piano",
             "flavor": "matches a piano (~450 kg)"
           },
           "scaleCar": {
+            "target": "10^30",
             "name": "Scale: Compact car",
             "flavor": "same as a compact car (~1.3 t)"
           },
           "scaleElephant": {
+            "target": "3 × 10^31",
             "name": "Scale: Elephant",
             "flavor": "equivalent to an elephant (~6 t)"
           },
           "scaleBoeing747": {
+            "target": "10^33",
             "name": "Scale: Boeing 747",
             "flavor": "same mass as a Boeing 747"
           },
           "scalePyramid": {
+            "target": "2 × 10^35",
             "name": "Scale: Great Pyramid of Giza",
             "flavor": "atoms of the Great Pyramid of Giza"
           },
           "scaleAtmosphere": {
+            "target": "2 × 10^44",
             "name": "Scale: Earth's atmosphere",
             "flavor": "equal to the full atmosphere of Earth"
           },
           "scaleOceans": {
+            "target": "10^47",
             "name": "Scale: Earth's oceans",
             "flavor": "matches all Earth's oceans"
           },
           "scaleEarth": {
+            "target": "10^50",
             "name": "Scale: Earth",
             "flavor": "equals the atomic mass of planet Earth"
           },
           "scaleSun": {
+            "target": "10^57",
             "name": "Scale: Sun",
             "flavor": "equivalent to the Sun"
           },
           "scaleMilkyWay": {
+            "target": "10^69",
             "name": "Scale: Milky Way",
             "flavor": "comparable to the entire Milky Way"
           },
           "scaleLocalGroup": {
+            "target": "10^71",
             "name": "Scale: Local Group",
             "flavor": "same as the Local Group of galaxies"
           },
           "scaleVirgoCluster": {
+            "target": "10^74",
             "name": "Scale: Virgo Supercluster",
             "flavor": "equivalent to the Virgo Supercluster"
           },
           "scaleObservableUniverse": {
+            "target": "10^80",
             "name": "Scale: Observable universe",
             "flavor": "reach the estimated atoms of the observable universe"
           }

--- a/scripts/i18n/fr.json
+++ b/scripts/i18n/fr.json
@@ -871,94 +871,117 @@
           "description": "Atteignez {target} atomes cumulés, {flavor}.",
           "reward": "Ajoute +{bonus} au Boost global sur la production manuelle et automatique (×{total} pour ce palier).",
           "scaleHumanCell": {
+            "target": "10^14",
             "name": "Échelle : cellule humaine",
             "flavor": "l’équivalent d’une cellule humaine « moyenne »"
           },
           "scaleSandGrain": {
+            "target": "10^19",
             "name": "Échelle : grain de sable",
             "flavor": "la masse d’un grain de sable (~1 mm)"
           },
           "scaleAnt": {
+            "target": "10^20",
             "name": "Échelle : fourmi",
             "flavor": "comparable à une fourmi (~5 mg)"
           },
           "scaleWaterDrop": {
+            "target": "5 × 10^21",
             "name": "Échelle : goutte d’eau",
             "flavor": "la quantité d’atomes contenue dans une goutte d’eau de 0,05 mL"
           },
           "scalePaperclip": {
+            "target": "10^22",
             "name": "Échelle : trombone",
             "flavor": "l’équivalent d’un trombone en fer (~1 g)"
           },
           "scaleCoin": {
+            "target": "10^23",
             "name": "Échelle : pièce",
             "flavor": "la masse atomique d’une pièce de monnaie (~7,5 g)"
           },
           "scaleApple": {
+            "target": "10^25",
             "name": "Échelle : pomme",
             "flavor": "la masse atomique d’une pomme (~100 g)"
           },
           "scaleSmartphone": {
+            "target": "3 × 10^25",
             "name": "Échelle : smartphone",
             "flavor": "autant qu’un smartphone moderne (~180 g)"
           },
           "scaleWaterLitre": {
+            "target": "10^26",
             "name": "Échelle : litre d’eau",
             "flavor": "l’équivalent d’un litre d’eau (~300 g)"
           },
           "scaleHuman": {
+            "target": "7 × 10^27",
             "name": "Échelle : être humain",
             "flavor": "comparable à un humain de 70 kg"
           },
           "scalePiano": {
+            "target": "10^29",
             "name": "Échelle : piano",
             "flavor": "équivaut à un piano (~450 kg)"
           },
           "scaleCar": {
+            "target": "10^30",
             "name": "Échelle : voiture compacte",
             "flavor": "autant qu’une voiture compacte (~1,3 t)"
           },
           "scaleElephant": {
+            "target": "3 × 10^31",
             "name": "Échelle : éléphant",
             "flavor": "équivaut à un éléphant (~6 t)"
           },
           "scaleBoeing747": {
+            "target": "10^33",
             "name": "Échelle : Boeing 747",
             "flavor": "autant qu’un Boeing 747"
           },
           "scalePyramid": {
+            "target": "2 × 10^35",
             "name": "Échelle : pyramide de Khéops",
             "flavor": "la masse d’atomes de la grande pyramide de Khéops"
           },
           "scaleAtmosphere": {
+            "target": "2 × 10^44",
             "name": "Échelle : atmosphère terrestre",
             "flavor": "équivaut à l’atmosphère terrestre complète"
           },
           "scaleOceans": {
+            "target": "10^47",
             "name": "Échelle : océans terrestres",
             "flavor": "autant que tous les océans de la Terre"
           },
           "scaleEarth": {
+            "target": "10^50",
             "name": "Échelle : Terre",
             "flavor": "égale la masse atomique de la planète Terre"
           },
           "scaleSun": {
+            "target": "10^57",
             "name": "Échelle : Soleil",
             "flavor": "équivaut au Soleil"
           },
           "scaleMilkyWay": {
+            "target": "10^69",
             "name": "Échelle : Voie lactée",
             "flavor": "comparable à la Voie lactée entière"
           },
           "scaleLocalGroup": {
+            "target": "10^71",
             "name": "Échelle : Groupe local",
             "flavor": "autant que le Groupe local de galaxies"
           },
           "scaleVirgoCluster": {
+            "target": "10^74",
             "name": "Échelle : superamas de la Vierge",
             "flavor": "équivaut au superamas de la Vierge"
           },
           "scaleObservableUniverse": {
+            "target": "10^80",
             "name": "Échelle : univers observable",
             "flavor": "atteignez le total estimé d’atomes de l’univers observable"
           }


### PR DESCRIPTION
## Summary
- translate SCALE trophy metadata from the JSON language bundles, including target strings for each SCALE achievement
- update the embedded i18n fallback data so SCALE trophies resolve localized names, descriptions, and rewards offline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daefa7a160832e9b6e7b0917076fc6