### PR TITLE
Use localized trophy descriptions on Goals page

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -646,6 +646,8 @@ function createAtomScaleTrophies() {
     return {
       id: entry.id,
       name: entry.name,
+      targetText: entry.targetText,
+      flavor: entry.flavor,
       description: translateOrDefault(
         'scripts.appData.atomScale.trophies.description',
         descriptionFallback,

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -7475,10 +7475,12 @@ function getTrophyDisplayTexts(def) {
   }
 
   let descriptionParams = null;
-  if (def.targetText || def.flavor) {
+  const descriptionTarget = def.targetText || '';
+  const descriptionFlavor = translateTrophyField(def, 'flavor', def.flavor || '');
+  if (descriptionTarget || descriptionFlavor) {
     descriptionParams = {
-      target: def.targetText || '',
-      flavor: def.flavor || ''
+      target: descriptionTarget,
+      flavor: descriptionFlavor
     };
   }
   let description = '';


### PR DESCRIPTION
## Summary
- expose atom scale trophy target and flavor metadata in the config
- reuse localized flavor strings when composing goal descriptions in the UI
- ensure goal cards use the translated JSON copy for their description text

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68daf84f0dcc832eaac5a590e39de26e